### PR TITLE
Adjusted .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,10 @@
 *.sdf
 *.suo
 *.user
-.vscode/*
-.vs/*
-.ycm_extra_conf.py
-.ycm_extra_conf.pyc
-/build*/
-/Externals/*
-ipch
+.vs/
+.vscode/
+.ycm_extra_conf.py*
+Externals/*/*
+build*/
+ipch/
 last_clobber.txt


### PR DESCRIPTION
Switched `Externals/*` to `Externals/*/*` and sorted lexicographically.  Having `Externals/*/*` will ignore all files within subfolders under `Externals` where as `Externals/*` will ignore all folders and files under `Externals`. The previous pattern caused issues with updating our `CMakeLists.txt` file under `Externals` as well as detecting sub-module updates under `Externals`.