### PR TITLE
Add input handling to ui system.

### DIFF
--- a/Libraries/WNContainers/inc/WNRangePartition.h
+++ b/Libraries/WNContainers/inc/WNRangePartition.h
@@ -200,38 +200,6 @@ private:
     m_next = nullptr;
     return true;
   }
-
-  WN_FORCE_INLINE partition_node<T_SIZE>* merge_left() {
-    WN_DEBUG_ASSERT(m_next_free, "Cannot merge wiht previous non-free block");
-    if (m_previous && m_previous->m_next_free) {
-      partition_node<T_SIZE>* p = m_previous;
-      m_next_free = m_previous->m_next_free;
-      m_size += m_previous->m_size;
-      m_previous = m_previous->m_previous;
-      if (m_previous) {
-        m_previous->m_next = this;
-      }
-      return p;
-    }
-    return nullptr;
-  }
-
-  partition_node<T_SIZE>* merge_right() {
-    WN_DEBUG_ASSERT(m_next_free, "Cannot merge wiht previous non-free block");
-    if (m_next && m_next->m_next_free) {
-      partition_node<T_SIZE>* n = m_next;
-      m_next_free = m_next->m_next_free;
-      m_size += m_next->m_size;
-
-      m_next = m_next->m_next;
-      if (m_next) {
-        m_next->m_previous = this;
-      }
-
-      return n;
-    }
-    return nullptr;
-  }
 };
 
 template <typename T_SIZE>
@@ -341,16 +309,6 @@ inline void range_partition<NodeAllocator, T_SIZE>::release_interval(
     m_used_space -= token.size();
     token.node->m_next_free = m_free_list;
     m_free_list = token.node;
-    partition_node<T_SIZE>* node;
-    if (0 != (node = m_free_list->merge_left())) {
-      if (!node->m_previous) {
-        m_node = m_free_list;
-      }
-      m_node_allocator.free_node(node);
-    }
-    if (0 != (node = m_free_list->merge_right())) {
-      m_node_allocator.free_node(node);
-    }
   }
   token.list = nullptr;
 }

--- a/engine/ui/inc/ui.h
+++ b/engine/ui/inc/ui.h
@@ -8,6 +8,7 @@
 #define __WN_ENGINE_UI_H__
 
 #include "Rocket/Core.h"
+#include "WNWindow/inc/WNInputContext.h"
 #include "renderer/inc/renderable_object.h"
 #include "ui/inc/ui_data.h"
 #include "ui/inc/ui_rocket_interop.h"
@@ -59,6 +60,8 @@ private:
   engine_base::context* m_context;
   scripting::engine* m_engine;
   scripting::shared_script_pointer<ui_data> m_data;
+  runtime::window::window* m_window = nullptr;
+  runtime::window::input_context* m_input_context;
   memory::unique_ptr<rocket_renderer> m_renderer;
   memory::unique_ptr<rocket_file_interface> m_file_interface;
   memory::unique_ptr<rocket_system_interface> m_system_interface;
@@ -67,6 +70,7 @@ private:
   memory::unique_ptr<Rocket::Core::Context> m_rocket_context;
   Rocket::Core::DocumentContext* m_document_context;
   Rocket::Core::ElementDocument* m_document;
+  bool m_debugger_visible = false;
 };
 
 }  // namespace ui

--- a/engine/ui/inc/ui_resources.h
+++ b/engine/ui/inc/ui_resources.h
@@ -21,6 +21,7 @@ namespace ui {
 
 class ui_resource {
 public:
+  virtual ~ui_resource() {}
   // returns true if this resource is still in use
   bool remove_from_frame(size_t _frame_parity) {
     frame_parity &= ~_frame_parity;
@@ -33,7 +34,7 @@ public:
 
 private:
   size_t frame_parity = 0;
-};
+};  // namespace ui
 
 // This is specifically an inline texture,
 // not a texture from a file.
@@ -83,6 +84,7 @@ public:
       m_texture(_texture),
       m_num_vertices(_verts),
       m_num_indices(_inds) {}
+  ~ui_geometry() {}
 
   runtime::graphics::buffer& vertex_buffer() {
     return m_vertex_buffer->buffer();


### PR DESCRIPTION
This adds basic input, still missing textures, also
still missing temporary geometry. Both of those should be easy.

This "fixes" a bug with the range parition where merging nodes
was not correct. We were dropping parts of the free-list and
overwriting data, it was bad.

The "fix" is to remove the merging behavior, so now the range
partition may easily get fragmented. To be fixed (#168)