### PR TITLE
Switch to container for clang-format

### DIFF
--- a/.github/workflows/format-checks.yml
+++ b/.github/workflows/format-checks.yml
@@ -8,14 +8,8 @@ jobs:
   check-code-format-c-cpp:
     name: Check code format (C/C++)
     runs-on: ubuntu-latest
+    container: ghcr.io/wnproject/clang-format
     steps:
-      - name: Install packages
-        run: sudo apt-get install -y clang-format-10
-      - name: Configure clang-format
-        run: >
-          sudo update-alternatives --remove-all clang-format &&
-          sudo update-alternatives --install /usr/bin/clang-format clang-format
-          /usr/bin/clang-format-10 100
       - name: Checkout code
         uses: actions/checkout@v2.3.3
       - name: Check code format


### PR DESCRIPTION
This cuts out the times used installing and configuring `clang-format`. Should also give us a more consistent way to control the `clang-format` version used.