### PR TITLE
Remove "Unix Makefiles" as a build generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         compiler: [clang, gcc]
         version: [9, 10]
-        generator: [Unix Makefiles, Ninja]
+        generator: [Ninja]
         build-type: [Debug, Release]
     steps:
       - name: Set up build environment


### PR DESCRIPTION
Removing since it is horribly slow and shouldn't be a problem since we don't do anything that is Ninja or Make specific.