### PR TITLE
Allow updates for all git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,3 @@ updates:
     labels:
       - auto
       - dependencies
-    allow:
-      - dependency-name: '*googletest'


### PR DESCRIPTION
If this doesn't work we can always revert. It should update all submodules to the latest commit on the tracked branch.

- [ ] Wait for android build to be up and running