### PR TITLE
Increase Windows container memory size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,12 @@ jobs:
           submodules: true
       - name: Pull container
         run: docker pull ${{steps.info.outputs.docker_image}}
+      - name: Get memory
+        run: >
+          docker run --rm
+          -e VS_ARCH=${{steps.info.outputs.vs_arch}}
+          ${{steps.info.outputs.docker_image}}
+          powershell -Command "(Get-CimInstance win32_computersystem).TotalPhysicalMemory"
       - name: Run configuration
         run: >
           docker run --rm


### PR DESCRIPTION
Windows containers default to 1 GB of memory on Windows 10/Server 2019. This caused the build to fail when linking sometimes. Increasing to 4 GB to help with compile/linking. Resolves #215.