### PR TITLE
Fix link warning

### DIFF
--- a/Overlays/Windows/cmake/build_options.cmake
+++ b/Overlays/Windows/cmake/build_options.cmake
@@ -93,6 +93,8 @@ add_compile_options(/D_WN_WINDOWS)
 
 # Linker options
 foreach(type EXE SHARED STATIC)
+  set(CMAKE_${type}_LINKER_FLAGS "${CMAKE_${type}_LINKER_FLAGS} /ignore:4221")
+
   # Enable link time code generation
   if(NOT "${CMAKE_${type}_LINKER_FLAGS_RELEASE}" MATCHES "/LTCG")
     set(CMAKE_${type}_LINKER_FLAGS_RELEASE

--- a/Runtime/WNGraphics/src/WNQueue.cpp
+++ b/Runtime/WNGraphics/src/WNQueue.cpp
@@ -7,18 +7,20 @@
 #include "WNGraphics/inc/Internal/WNConfig.h"
 #include "WNGraphics/inc/WNDevice.h"
 
+#ifdef _WN_GRAPHICS_SINGLE_DEVICE_TYPE
+
 namespace wn {
 namespace runtime {
 namespace graphics {
 
-#ifdef _WN_GRAPHICS_SINGLE_DEVICE_TYPE
 queue::~queue() {
   if (is_valid()) {
     m_device->destroy_queue(this);
   }
 }
-#endif
 
 }  // namespace graphics
 }  // namespace runtime
 }  // namespace wn
+
+#endif

--- a/Runtime/WNGraphics/src/WNSurface.cpp
+++ b/Runtime/WNGraphics/src/WNSurface.cpp
@@ -21,6 +21,7 @@ graphics_error surface::get_surface_capabilities(
     surface_capabilities* _capabilities) {
   return m_adapter->get_surface_capabilities(this, _capabilities);
 }
+
 }  // namespace graphics
 }  // namespace runtime
 }  // namespace wn


### PR DESCRIPTION
This fixes warning about no previously undefined symbols being defined by this file.