### PR TITLE
Rename builds again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,9 @@ jobs:
           -iregex '^\.\/\(externals\|build.*\).*$' |
           xargs clang-format --dry-run --Werror --verbose
   build-linux:
-    name: >
-      Build (Linux:
-      x86-64/${{matrix.compiler}}-${{matrix.version}}/${{matrix.build-type}})
+    name: 'Build (Linux: x86-64/${{matrix.compiler}}-${{matrix.version}}/${{matrix.build-type}})'
     runs-on: ubuntu-latest
-    container:
-      ghcr.io/wnproject/build-linux:${{matrix.compiler}}-${{matrix.version}}
+    container: ghcr.io/wnproject/build-linux:${{matrix.compiler}}-${{matrix.version}}
     strategy:
       fail-fast: false
       matrix:
@@ -48,9 +45,7 @@ jobs:
       - name: Report build details
         run: du -hbcs ./source ./build
   build-windows:
-    name: >
-      Build (Windows:
-      ${{matrix.architecture}}/msvc-${{matrix.version}}/${{matrix.build-type}})
+    name: 'Build (Windows: ${{matrix.architecture}}/msvc-${{matrix.version}}/${{matrix.build-type}})'
     runs-on: windows-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
I noticed, when inspecting via GitHub API, that the ones that didn't work ended up having a random `\n` on the end. I'm guessing trying to do multiline yml in the name was causing issues. Linearizing the name field. This makes it longer than 80 chars but I think that's fine for the build scripts.