### PR TITLE
Always report build details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
         working-directory: ./build
         run: cmake --build .
       - name: Report build details
+        if: success() || failure()
         run: du -hbcs ./source ./build
   build-windows:
     name: 'Build (Windows: ${{matrix.architecture}}/msvc-${{matrix.version}}/${{matrix.build-type}})'
@@ -113,5 +114,6 @@ jobs:
           ${{steps.info.outputs.docker_image}}
           cmake --build C:\workspace\build
       - name: Report build details
+        if: success() || failure()
         shell: bash
         run: du -hbcs ./source ./build


### PR DESCRIPTION
This will report build details on all successful or failed runs. This will not display if the run was cancelled.