### PR TITLE
Make clang-format ignore data driven

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,1 @@
+externals/*/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,21 @@ jobs:
     name: Analyze changes
     runs-on: ubuntu-latest
     outputs:
-      run-build: ${{steps.change-analysis.outputs.run-build}}
-      run-format-check: ${{steps.change-analysis.outputs.run-format-check}}
-      code-changes: ${{steps.change-analysis.outputs.code-changes}}
+      run-build: ${{steps.analysis.outputs.run-build}}
+      run-format-check-c-cpp: ${{steps.analysis.outputs.run-format-check-c-cpp}}
+      code-changes-c-cpp: ${{steps.analysis.outputs.code-changes-c-cpp}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
       - name: Analyze changes
-        id: change-analysis
+        id: analysis
         shell: bash
         run: |
-          if [ '${{github.ref}}' == 'refs/heads/master' ]; then
-            build_changes='true'
-            format_changes='true'
+          if [ ${{github.ref}} == refs/heads/master ]; then
+            build_changes=true
+            format_changes=true
             code_changes=$(
               find . -type f \
               -iregex '^.*\.\(c\|cpp\|h\|hpp\|inl\)$' -and -not \
@@ -37,35 +37,42 @@ jobs:
               ':!.github/dependabot.yml' ':!.github/workflows/sync-labels.yml'
             )
             if [ -z "$build_changes" ]; then
-              build_changes='false'
+              build_changes=false
             else
-              build_changes='true'
+              build_changes=true
             fi
+            code_changes_ignore=()
+            while IFS= read -r line; do
+              code_changes_ignore+=(":!$line")
+            done < .clang-format-ignore
             code_changes=$(
-              git diff --name-only origin/master HEAD -- \
-              ':!externals/*/*' *.c *.cpp *.h *.hpp *.inl .clang-format
+              git diff --name-only origin/master HEAD -- *.c *.cpp *.h *.hpp \
+              *.inl .clang-format .clang-format-ignore \
+              "${code_changes_ignore[@]}"
             )
             if [ -z "$code_changes" ]; then
-              format_changes='false'
+              format_changes=false
             else
-              format_changes='true'
-              code_changes=$(echo "$code_changes" | grep -v .clang-format)
+              format_changes=true
+              code_changes=$(
+                echo "$code_changes" | grep -ve '^.clang-format' || true
+              )
             fi
           fi
           echo "Run build: $build_changes"
-          echo "Run format check: $format_changes"
+          echo "Run format check (C/C++): $format_changes"
           if [ -z "$code_changes" ]; then
-            echo 'Code changes: [none]'
+            echo 'Code changes (C/C++): [none]'
           else
-            echo "Code changes: $code_changes"
+            echo "Code changes (C/C++): $code_changes"
           fi
           echo "::set-output name=run-build::$build_changes"
-          echo "::set-output name=run-format-check::$format_changes"
-          echo "::set-output name=code-changes::$code_changes"
-  check-code-formatting:
-    name: Check code formatting
+          echo "::set-output name=run-format-check-c-cpp::$format_changes"
+          echo "::set-output name=code-changes-c-cpp::$code_changes"
+  check-code-formatting-c-cpp:
+    name: Check code formatting (C/C++)
     needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-format-check == 'true'
+    if: needs.analyze-changes.outputs.run-format-check-c-cpp == 'true'
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/clang-format
     steps:
@@ -73,7 +80,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Check code format
         run: >
-          echo "${{needs.analyze-changes.outputs.code-changes}}" |
+          echo ${{needs.analyze-changes.outputs.code-changes-c-cpp}} |
           xargs clang-format --dry-run --Werror
   build-android:
     name: Build Android
@@ -274,8 +281,8 @@ jobs:
         run: |
           results=( ${{join(needs.*.result, ' ')}} )
           for result in "${results[@]}"; do
-            if [ "$result" != 'success' ]; then
-              echo 'Build failed'
+            if [ "$result" != success ]; then
+              echo Build failed
               exit 1
             fi
           done


### PR DESCRIPTION
This grabs the list of ignore items for clang-format from a file called `.clang-format-ignore`. This can have standard blob style paths and works similar to .gitignore but does not have negation (can't use ! in front of a path to make it get included).