### PR TITLE
Always run build aggregation job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -457,7 +457,7 @@ jobs:
       - build-android
       - build-linux
       - build-windows
-    if: success() || failure()
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Accumulate build status


### PR DESCRIPTION
Builds would be considered successful on build cancel.