### PR TITLE
Fix windows builds

### DIFF
--- a/Overlays/Windows/cmake/externals.cmake
+++ b/Overlays/Windows/cmake/externals.cmake
@@ -1,4 +1,3 @@
-
 foreach(EXTERNAL_TARGET ${EXTERNAL_TARGETS})
     set_property(
       TARGET ${EXTERNAL_TARGET}
@@ -7,9 +6,14 @@ foreach(EXTERNAL_TARGET ${EXTERNAL_TARGETS})
 
     if (WN_USE_SCCACHE)
       get_target_property(CFLAGS ${EXTERNAL_TARGET} COMPILE_FLAGS)
-      string(REGEX REPLACE "/Zi" "" CFLAGS ${CFLAGS})
-      string(REGEX REPLACE "-Zi" "" CFLAGS ${CFLAGS})
-      set_target_properties(${EXTERNAL_TARGET} PROPERTIES 
-        COMPILE_FLAGS "${CFLAGS}")
+      if (COMPILE_FLAGS AND NOT COMPILE_FLAGS MATCHES ".*NOTFOUND")
+        string(REGEX REPLACE "/Zi" "" CFLAGS ${CFLAGS})
+        string(REGEX REPLACE "-Zi" "" CFLAGS ${CFLAGS})
+        set_target_properties(
+          ${EXTERNAL_TARGET}
+          PROPERTIES
+            COMPILE_FLAGS "${CFLAGS}"
+        )
+      endif()
     endif()
 endforeach()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -156,7 +156,6 @@ if(WN_ENABLE_TRACY)
   set(TRACY_OPTIONS TRACY_ENABLE)
 endif()
 
-
 add_wn_library(
   tracy_client
   SOURCES
@@ -168,7 +167,6 @@ add_wn_library(
   COMPILE_OPTIONS
     -DENABLE_PRELOAD
     -DTRACY_TIMER_FALLBACK
-    
 )
 
 add_wn_externals(


### PR DESCRIPTION
The use of [get_target_property](https://cmake.org/cmake/help/v3.16/command/get_target_property.html?highlight=get_target_property) can result in the variable `COMPILE_FLAGS` being set to either `NOTFOUND` or `CFLAGS-NOTFOUND` depending on cmake version. This will hopefully catch both. Not sure why this started not working all of a sudden but this seems to have fixed it.