### PR TITLE
Update linux compilers and fix OOM issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   analyze-changes:
     name: Analyze changes
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
       run-build: ${{steps.analysis.outputs.run-build}}
@@ -134,6 +135,7 @@ jobs:
     name: Check licenses
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-check-licenses == 'true'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -250,6 +252,7 @@ jobs:
     name: Check formatting (C/C++)
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-format-check-c-cpp == 'true'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/clang-format
     steps:
@@ -263,6 +266,7 @@ jobs:
     name: Check formatting (Markdown)
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-format-check-md == 'true'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/markdown-lint
     steps:
@@ -276,6 +280,7 @@ jobs:
     name: Build Android
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-build == 'true'
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-android
     strategy:
@@ -329,16 +334,19 @@ jobs:
     name: Build Linux
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-build == 'true'
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-linux:${{matrix.compiler}}
     strategy:
       fail-fast: false
       matrix:
         compiler:
-          - clang-9
           - clang-10
+          - clang-11
+          - clang-12
           - gcc-9
           - gcc-10
+          - gcc-11
         build-type:
           - Debug
           - Release
@@ -355,6 +363,7 @@ jobs:
         run: >
           cmake -GNinja
           -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+          -DWN_LOW_RESOURCE_MODE=ON
           ../source
       - name: Run build
         working-directory: ./build
@@ -363,7 +372,8 @@ jobs:
         working-directory: ./build
         run: >
           ctest -C ${{matrix.build-type}}
-          -LE REQUIRES_HARDWARE --output-on-failure
+          -LE REQUIRES_HARDWARE
+          --output-on-failure
       - name: Report build details
         if: success() || failure()
         run: du -hbcs ./source ./build
@@ -371,6 +381,7 @@ jobs:
     name: Build Windows
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-build == 'true'
+    timeout-minutes: 90
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -442,6 +453,7 @@ jobs:
       - build-linux
       - build-windows
     if: always()
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Accumulate build status

--- a/Overlays/Posix/Overlays/GCC/cmake/build_options.cmake
+++ b/Overlays/Posix/Overlays/GCC/cmake/build_options.cmake
@@ -7,7 +7,13 @@ add_compile_options(-Wno-stringop-truncation)
 add_compile_options(-Wno-unused-function)
 add_compile_options(-Wno-unused-variable)
 add_compile_options(-Wno-strict-aliasing)
+add_compile_options(-Wno-nonnull)
 add_compile_options(-Wno-nonnull-compare)
+
+if(WN_LOW_RESOURCE_MODE)
+  add_link_options($<$<CONFIG:Debug>:-Wl,--reduce-memory-overheads>)
+  add_link_options($<$<CONFIG:Debug>:-Wl,--no-keep-memory>)
+endif()
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9)
   add_compile_options(-Wno-error=maybe-uninitialized)

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ for that host.
 
 The following packages are required.
 
-* gcc
-* g++
-* git
-* clang
-* cmake
-* ninja-build
-* python3
-* libx11-xcb-dev
-* libxcb-keysyms1-dev
+* **gcc** (currently only `gcc-9`, `gcc-10` and `gcc-11` are supported)
+* **g++** (currently only `g++-9`, `g++-10` and `g++-11` are supported)
+* **git**
+* **clang** (currently only `clang-10`, `clang-11` and `clang-12` are supported)
+* **cmake** (minimum of **CMake 3.16** required)
+* **ninja-build**
+* **python3**
+* **libx11-xcb-dev**
+* **libxcb-keysyms1-dev**
 
 If you want to use **Unix Makefiles** as a generator you will also need the
 following.
 
-* make
+* **make**
 
 ### Configuration
 
@@ -55,10 +55,10 @@ cmake \
 Note that `Ninja` is the only offically supported generator for **Linux**. If
 `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILE` are omitted **CMake** will configure
 against the default system configured compilers. You can also specify specific
-versions of `gcc` or `clang` (`gcc-9.0`, `clang++-10.0`, etc.) if you have more
+versions of `gcc` or `clang` (`gcc-10.0`, `clang++-11.0`, etc.) if you have more
 then a single version installed and want to target a certain version. Currently
-only `gcc/g++` **9** and **10** are supported along with `clang` **9** and
-**10**.
+only `gcc/g++` **9**, **10** and **11** are supported along with `clang` **10**,
+**11** and **12**.
 
 #### Windows
 


### PR DESCRIPTION
This drops `clang` **9** and adds `gcc` **11** and `clang` **11** and **12**. Resolves #408.