### PR TITLE
Fix for scripting engine.

### DIFF
--- a/Libraries/WNScripting/inc/WNEngine.inl
+++ b/Libraries/WNScripting/inc/WNEngine.inl
@@ -123,6 +123,7 @@ struct member_maker {
   template <R (*fn)(Args...)>
   static typename get_thunk_passed_type<R>::ret_type member_thunk(
       typename get_thunk_passed_type<Args>::type... args) {
+    tls_resetter reset;
     auto r = (*fn)(get_thunk_passed_type<Args>::unwrap(args)...);
     return get_thunk_passed_type<R>::wrap(r);
   }
@@ -131,6 +132,7 @@ struct member_maker {
   static void return_member_thunk(
       typename get_thunk_passed_type<Args>::type... args,
       typename get_thunk_passed_type<R>::ret_type* _ret) {
+    tls_resetter reset;
     auto r = (*fn)(get_thunk_passed_type<Args>::unwrap(args)...);
     *_ret = get_thunk_passed_type<R>::wrap(r);
   }
@@ -141,12 +143,14 @@ struct member_maker<void, Args...> {
   static const bool is_ret_by_ref = false;
   template <void (*fn)(Args...)>
   static void member_thunk(typename get_thunk_passed_type<Args>::type... args) {
+    tls_resetter reset;
     return (*fn)(get_thunk_passed_type<Args>::unwrap(args)...);
   }
 
   template <void (*fn)(Args...)>
   static void return_member_thunk(
       typename get_thunk_passed_type<Args>::type... args) {
+    tls_resetter reset;
     (*fn)(get_thunk_passed_type<Args>::unwrap(args)...);
   }
 };

--- a/Libraries/WNScripting/inc/WNFactory.h
+++ b/Libraries/WNScripting/inc/WNFactory.h
@@ -48,8 +48,6 @@ public:
       file_system::mapping* _output_mapping, logging::log* _log);
 };
 
-extern thread_local const scripting_tls_data* g_scripting_tls;
-
 }  // namespace scripting
 }  // namespace wn
 

--- a/Libraries/WNScripting/inc/WNScriptHelpers.h
+++ b/Libraries/WNScripting/inc/WNScriptHelpers.h
@@ -275,7 +275,7 @@ inline T& fixup_return_type(T& _i) {
 template <typename T>
 inline script_pointer<T>& fixup_return_type(script_pointer<T>& t) {
   t.unsafe_set_type(reinterpret_cast<T*>(
-      (*g_scripting_tls->_object_types)[core::type_id<T>::value()].get()));
+      (*get_scripting_tls()->_object_types)[core::type_id<T>::value()].get()));
   return t;
 }
 
@@ -283,13 +283,13 @@ template <typename T>
 inline shared_script_pointer<T>& fixup_return_type(
     shared_script_pointer<T>& t) {
   t.unsafe_set_type(reinterpret_cast<T*>(
-      (*g_scripting_tls->_object_types)[core::type_id<T>::value()].get()));
+      (*get_scripting_tls()->_object_types)[core::type_id<T>::value()].get()));
   return t;
 }
 
 template <typename T>
 inline shared_cpp_pointer<T>& fixup_return_type(shared_cpp_pointer<T>& t) {
-  t.unsafe_set_engine_free(g_scripting_tls->_engine, &do_engine_free);
+  t.unsafe_set_engine_free(get_scripting_tls()->_engine, &do_engine_free);
   return t;
 }
 
@@ -297,7 +297,7 @@ template <typename T>
 inline wn_array<script_pointer<T>>& fixup_return_type(
     wn_array<script_pointer<T>>& t) {
   t.unsafe_set_type(reinterpret_cast<T*>(
-      (*g_scripting_tls->_object_types)[core::type_id<T>::value()].get()));
+      (*get_scripting_tls()->_object_types)[core::type_id<T>::value()].get()));
   return t;
 }
 
@@ -305,7 +305,7 @@ template <typename T>
 inline wn_array<shared_script_pointer<T>>& fixup_return_type(
     wn_array<shared_script_pointer<T>>& t) {
   t.unsafe_set_type(reinterpret_cast<T*>(
-      (*g_scripting_tls->_object_types)[core::type_id<T>::value()].get()));
+      (*get_scripting_tls()->_object_types)[core::type_id<T>::value()].get()));
   return t;
 }
 

--- a/Libraries/WNScripting/inc/WNScriptTLS.h
+++ b/Libraries/WNScripting/inc/WNScriptTLS.h
@@ -22,22 +22,23 @@ struct scripting_tls_data final {
   logging::log* _log;
   memory::allocator* _support_allocator;
 };
+const scripting_tls_data*& get_scripting_tls();
 
 extern thread_local const scripting_tls_data* g_scripting_tls;
 
 class tls_resetter final {
 public:
   tls_resetter() {
-    m_data = g_scripting_tls;
+    m_data = get_scripting_tls();
   }
 
   tls_resetter(const scripting_tls_data* _tls_data) {
-    m_data = g_scripting_tls;
-    g_scripting_tls = _tls_data;
+    m_data = get_scripting_tls();
+    get_scripting_tls() = _tls_data;
   }
 
   ~tls_resetter() {
-    g_scripting_tls = m_data;
+    get_scripting_tls() = m_data;
   }
 
 private:

--- a/Libraries/WNScripting/src/WNFactory.cpp
+++ b/Libraries/WNScripting/src/WNFactory.cpp
@@ -47,5 +47,9 @@ void do_engine_free(const engine* _engine, void* v) {
 
 thread_local const scripting_tls_data* g_scripting_tls = nullptr;
 
+const scripting_tls_data*& get_scripting_tls() {
+  return g_scripting_tls;
+}
+
 }  // namespace scripting
 }  // namespace wn

--- a/engine/engine/src/script_export.cpp
+++ b/engine/engine/src/script_export.cpp
@@ -18,7 +18,7 @@ void sleep(int32_t _seconds) {
 };
 
 void log_error(const char* _str) {
-  scripting::g_scripting_tls->_log->log_error(_str);
+  scripting::get_scripting_tls()->_log->log_error(_str);
 }
 
 }  // anonymous namespace

--- a/engine/support/src/log.cpp
+++ b/engine/support/src/log.cpp
@@ -12,41 +12,41 @@ namespace {
 struct log_flusher {};
 
 log_flusher* _error() {
-  scripting::g_scripting_tls->_log->log_params(logging::log_level::error,
+  scripting::get_scripting_tls()->_log->log_params(logging::log_level::error,
       static_cast<size_t>(logging::log_flags::no_newline));
   return reinterpret_cast<log_flusher*>(
       static_cast<uintptr_t>(logging::log_level::error));
 }
 
 log_flusher* _warning() {
-  scripting::g_scripting_tls->_log->log_params(logging::log_level::warning,
+  scripting::get_scripting_tls()->_log->log_params(logging::log_level::warning,
       static_cast<size_t>(logging::log_flags::no_newline));
   return reinterpret_cast<log_flusher*>(
       static_cast<uintptr_t>(logging::log_level::warning));
 }
 log_flusher* _info() {
-  scripting::g_scripting_tls->_log->log_params(logging::log_level::info,
+  scripting::get_scripting_tls()->_log->log_params(logging::log_level::info,
       static_cast<size_t>(logging::log_flags::no_newline));
   return reinterpret_cast<log_flusher*>(
       static_cast<uintptr_t>(logging::log_level::info));
 }
 
 log_flusher* _critical() {
-  scripting::g_scripting_tls->_log->log_params(logging::log_level::critical,
+  scripting::get_scripting_tls()->_log->log_params(logging::log_level::critical,
       static_cast<size_t>(logging::log_flags::no_newline));
   return reinterpret_cast<log_flusher*>(
       static_cast<uintptr_t>(logging::log_level::critical));
 }
 
 log_flusher* _issue() {
-  scripting::g_scripting_tls->_log->log_params(logging::log_level::issue,
+  scripting::get_scripting_tls()->_log->log_params(logging::log_level::issue,
       static_cast<size_t>(logging::log_flags::no_newline));
   return reinterpret_cast<log_flusher*>(
       static_cast<uintptr_t>(logging::log_level::issue));
 }
 
 log_flusher* _debug() {
-  scripting::g_scripting_tls->_log->log_params(
+  scripting::get_scripting_tls()->_log->log_params(
 
       logging::log_level::debug,
       static_cast<size_t>(logging::log_flags::no_newline));
@@ -58,14 +58,14 @@ log_flusher* _o_cstr(log_flusher* fl, const char* str) {
   logging::log_level l =
       static_cast<logging::log_level>(reinterpret_cast<uintptr_t>(fl));
   if (!str) {
-    scripting::g_scripting_tls->_log->log_params(l,
+    scripting::get_scripting_tls()->_log->log_params(l,
         static_cast<size_t>(logging::log_flags::no_newline) |
             static_cast<size_t>(logging::log_flags::no_header),
         "<nullptr>");
   }
   size_t s = ::strlen(str);
   for (size_t i = 0; i < s; i += 512) {
-    scripting::g_scripting_tls->_log->log_params(l,
+    scripting::get_scripting_tls()->_log->log_params(l,
         static_cast<size_t>(logging::log_flags::no_newline) |
             static_cast<size_t>(logging::log_flags::no_header),
         containers::string_view(str + i, (s - i > 512) ? 512 : s - i));
@@ -77,7 +77,7 @@ log_flusher* _o_cstr(log_flusher* fl, const char* str) {
 log_flusher* _o_int(log_flusher* fl, int32_t val) {
   logging::log_level l =
       static_cast<logging::log_level>(reinterpret_cast<uintptr_t>(fl));
-  scripting::g_scripting_tls->_log->log_params(l,
+  scripting::get_scripting_tls()->_log->log_params(l,
       static_cast<size_t>(logging::log_flags::no_newline) |
           static_cast<size_t>(logging::log_flags::no_header),
       val);
@@ -87,7 +87,7 @@ log_flusher* _o_int(log_flusher* fl, int32_t val) {
 log_flusher* _o_bool(log_flusher* fl, bool val) {
   logging::log_level l =
       static_cast<logging::log_level>(reinterpret_cast<uintptr_t>(fl));
-  scripting::g_scripting_tls->_log->log_params(l,
+  scripting::get_scripting_tls()->_log->log_params(l,
       static_cast<size_t>(logging::log_flags::no_newline) |
           static_cast<size_t>(logging::log_flags::no_header),
       val ? "true" : "false");
@@ -97,7 +97,7 @@ log_flusher* _o_bool(log_flusher* fl, bool val) {
 log_flusher* _o_float(log_flusher* fl, float val) {
   logging::log_level l =
       static_cast<logging::log_level>(reinterpret_cast<uintptr_t>(fl));
-  scripting::g_scripting_tls->_log->log_params(l,
+  scripting::get_scripting_tls()->_log->log_params(l,
       static_cast<size_t>(logging::log_flags::no_newline) |
           static_cast<size_t>(logging::log_flags::no_header),
       val);
@@ -107,7 +107,7 @@ log_flusher* _o_float(log_flusher* fl, float val) {
 void _end(log_flusher* fl) {
   logging::log_level l =
       static_cast<logging::log_level>(reinterpret_cast<uintptr_t>(fl));
-  scripting::g_scripting_tls->_log->log_params(
+  scripting::get_scripting_tls()->_log->log_params(
       l, static_cast<size_t>(logging::log_flags::no_header));
 }
 

--- a/engine/support/src/string.cpp
+++ b/engine/support/src/string.cpp
@@ -23,8 +23,8 @@ struct exported_script_type<support::string> {
 namespace support {
 
 scripting::shared_cpp_pointer<string> make_string(const char* _re) {
-  return scripting::g_scripting_tls->_engine->make_shared_cpp<string>(
-      _re, scripting::g_scripting_tls->_support_allocator);
+  return scripting::get_scripting_tls()->_engine->make_shared_cpp<string>(
+      _re, scripting::get_scripting_tls()->_support_allocator);
 }
 
 void string::register_scripting(

--- a/engine/support/src/subprocess.cpp
+++ b/engine/support/src/subprocess.cpp
@@ -49,42 +49,42 @@ namespace support {
 scripting::shared_cpp_pointer<subprocess> make_subprocess(
     engine_base::context* _context, const char* _program,
     scripting::slice<const char*> _args) {
-  return scripting::g_scripting_tls->_engine->make_shared_cpp<subprocess>(
-      scripting::g_scripting_tls->_support_allocator, _context, _program,
+  return scripting::get_scripting_tls()->_engine->make_shared_cpp<subprocess>(
+      scripting::get_scripting_tls()->_support_allocator, _context, _program,
       _args);
 }
 
 scripting::shared_cpp_pointer<subprocess> make_subprocess2(
     engine_base::context* _context, const char* _program) {
-  return scripting::g_scripting_tls->_engine->make_shared_cpp<subprocess>(
-      scripting::g_scripting_tls->_support_allocator, _context, _program,
+  return scripting::get_scripting_tls()->_engine->make_shared_cpp<subprocess>(
+      scripting::get_scripting_tls()->_support_allocator, _context, _program,
       scripting::slice<const char*>());
 }
 
 scripting::shared_cpp_pointer<subprocess> make_subprocess3(
     engine_base::context* _context, const char* _program,
     scripting::shared_cpp_pointer<subprocess_args> _args) {
-  return scripting::g_scripting_tls->_engine->make_shared_cpp<subprocess>(
-      scripting::g_scripting_tls->_support_allocator, _context, _program,
+  return scripting::get_scripting_tls()->_engine->make_shared_cpp<subprocess>(
+      scripting::get_scripting_tls()->_support_allocator, _context, _program,
       _args.get());
 }
 
 scripting::shared_cpp_pointer<subprocess_args> make_subprocess_args(
     engine_base::context* _context) {
-  return scripting::g_scripting_tls->_engine->make_shared_cpp<subprocess_args>(
-      _context);
+  return scripting::get_scripting_tls()
+      ->_engine->make_shared_cpp<subprocess_args>(_context);
 }
 
 int32_t call_subprocess(
     const char* _program, scripting::slice<const char*> _args) {
   containers::dynamic_array<containers::string_view> arr(
-      scripting::g_scripting_tls->_support_allocator);
+      scripting::get_scripting_tls()->_support_allocator);
   for (auto& sv : _args) {
     arr.push_back(sv);
   }
   runtime::platform_utils::subprocess_return ret =
       runtime::platform_utils::call_subprocess(
-          scripting::g_scripting_tls->_support_allocator,
+          scripting::get_scripting_tls()->_support_allocator,
           containers::string_view(_program),
           containers::contiguous_range<containers::string_view>(arr));
   return runtime::platform_utils::subprocess_error::ok == ret.err
@@ -117,17 +117,17 @@ subprocess::subprocess(memory::allocator* _allocator,
     const subprocess_args* _args)
   : m_signal(_context->m_application_data->default_job_pool->get_signal()) {
   containers::dynamic_array<containers::string> args(
-      scripting::g_scripting_tls->_support_allocator);
+      scripting::get_scripting_tls()->_support_allocator);
   for (const auto& sv : _args->args) {
     args.push_back(containers::string(_allocator, sv));
   }
 
   containers::string prog(_allocator, _program);
-  auto tls = scripting::g_scripting_tls;
+  auto tls = scripting::get_scripting_tls();
   _context->m_application_data->default_job_pool->call_blocking_function(
       JOB_NAME,
       functional::function<void()>(
-          scripting::g_scripting_tls->_support_allocator,
+          scripting::get_scripting_tls()->_support_allocator,
           [this, tls, prog{core::move(prog)}, args{core::move(args)}]() {
             containers::dynamic_array<containers::string_view> arr(
                 tls->_support_allocator);
@@ -146,16 +146,16 @@ subprocess::subprocess(memory::allocator* _allocator,
     const scripting::slice<const char*> _args)
   : m_signal(_context->m_application_data->default_job_pool->get_signal()) {
   containers::dynamic_array<containers::string> args(
-      scripting::g_scripting_tls->_support_allocator);
+      scripting::get_scripting_tls()->_support_allocator);
   for (const auto& sv : _args) {
     args.push_back(containers::string(_allocator, sv));
   }
   containers::string prog(_allocator, _program);
-  auto tls = scripting::g_scripting_tls;
+  auto tls = scripting::get_scripting_tls();
   _context->m_application_data->default_job_pool->call_blocking_function(
       JOB_NAME,
       functional::function<void()>(
-          scripting::g_scripting_tls->_support_allocator,
+          scripting::get_scripting_tls()->_support_allocator,
           [this, tls, prog{core::move(prog)}, args{core::move(args)}]() {
             containers::dynamic_array<containers::string_view> arr(
                 tls->_support_allocator);

--- a/engine/ui/src/ui_scripting_event_instancer.cpp
+++ b/engine/ui/src/ui_scripting_event_instancer.cpp
@@ -13,8 +13,9 @@ void ui_set_property(
 };
 
 scripting::shared_cpp_pointer<support::string> make_string(const char* _str) {
-  return scripting::g_scripting_tls->_engine->make_shared_cpp<support::string>(
-      _str, scripting::g_scripting_tls->_support_allocator);
+  return scripting::get_scripting_tls()
+      ->_engine->make_shared_cpp<support::string>(
+          _str, scripting::get_scripting_tls()->_support_allocator);
 }
 
 scripting::shared_cpp_pointer<support::string> ui_get_property(


### PR DESCRIPTION
We were failing to retain the TLS data if we happened to hop
fibers during a call, this meant that if we created a window
and woke up on a new thread, we would have null tls data
meaning we could not make a call properly.