### PR TITLE
Re-enable linux sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,16 +358,30 @@ jobs:
         with:
           path: ./source
           submodules: true
+      - name: Set up gcs key
+        shell: bash
+        run: echo "$GCS_KEY" > /tmp/gcs_key.json
+        env:
+          GCS_KEY: ${{secrets.SCCACHE_GCS_KEY}}
       - name: Run configuration
         working-directory: ./build
         run: >
           cmake -GNinja
           -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
           -DWN_LOW_RESOURCE_MODE=ON
+          -DWN_USE_SCCACHE=ON
           ../source
+        env:
+          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
+          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
+          SCCACHE_GCS_RW_MODE: READ_WRITE
       - name: Run build
         working-directory: ./build
         run: cmake --build .
+        env:
+          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
+          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
+          SCCACHE_GCS_RW_MODE: READ_WRITE
       - name: Run tests
         working-directory: ./build
         run: >


### PR DESCRIPTION
Only re-enabling for linux right now. Still disabled for android.