### PR TITLE
Small fix to logging.

### DIFF
--- a/Runtime/WNApplicationEntry/src/WNApplicationEntry.cpp
+++ b/Runtime/WNApplicationEntry/src/WNApplicationEntry.cpp
@@ -65,7 +65,7 @@ int32_t wn_main(const wn::executable::executable_data* _data) {
   {
     main_application app;
     wn::multi_tasking::job_pool job_pool(
-        &root_allocator, log.log(), 2, 1024 * 1024 * 24, true);
+        &root_allocator, log.log(), 2, 1024 * 1024 * 2, true);
     wn::multi_tasking::signal_ptr main_done_signal = job_pool.get_signal();
     params.data.default_job_pool = &job_pool;
     // TODO(awoloszyn): Finish fiber job pool, start using that instead

--- a/externals/librocket/Source/Core/TTFFont/FontFaceHandle.cpp
+++ b/externals/librocket/Source/Core/TTFFont/FontFaceHandle.cpp
@@ -50,8 +50,6 @@ bool FontFaceHandle::Initialise(
   base_layer = GenerateLayer(NULL);
   layer_configurations.push_back(LayerConfiguration());
   layer_configurations.back().push_back(base_layer);
-  //Log::Message(m_context, Log::LT_INFO, "Loaded font %s at size %d.",
-    //  m_ttf_face->Face.FamilyName.CString(), size);
   return true;
 }
 

--- a/externals/librocket/Source/Core/TTFFont/FontFaceHandle.cpp
+++ b/externals/librocket/Source/Core/TTFFont/FontFaceHandle.cpp
@@ -50,8 +50,8 @@ bool FontFaceHandle::Initialise(
   base_layer = GenerateLayer(NULL);
   layer_configurations.push_back(LayerConfiguration());
   layer_configurations.back().push_back(base_layer);
-  Log::Message(m_context, Log::LT_INFO, "Loaded font %s at size %d.",
-      m_ttf_face->Face.FamilyName.CString(), size);
+  //Log::Message(m_context, Log::LT_INFO, "Loaded font %s at size %d.",
+    //  m_ttf_face->Face.FamilyName.CString(), size);
   return true;
 }
 


### PR DESCRIPTION
This could create a terrible loop of loading fonts forever (or at least until a stack overflow). If we have the UI debugger around then logging will try to write UI log, whihc may load a font, which may log with may try to load a font etc etc.