### PR TITLE
Another update to simplify actors.

### DIFF
--- a/Libraries/WNScripting/inc/WNScriptTLS.h
+++ b/Libraries/WNScripting/inc/WNScriptTLS.h
@@ -45,7 +45,7 @@ public:
   // accomplished immediately, but you are responsible for
   // making sure that no actor is completing 2 actions at
   // the same time.
-  virtual void call_actor_function(actor_function* function) = 0;
+  virtual void call_actor_function(int32_t delay, actor_function* function) = 0;
 };
 
 struct scripting_tls_data final {

--- a/Libraries/WNScripting/inc/ast_node_types.h
+++ b/Libraries/WNScripting/inc/ast_node_types.h
@@ -797,6 +797,7 @@ struct ast_function : public ast_node {
   bool m_is_synchronized = false;
   bool m_is_action_caller = false;
   ast_function* m_action_function = nullptr;
+  ast_function* m_action_call_function = nullptr;
 
   uint32_t m_virtual_index = 0xFFFFFFFF;
 

--- a/Libraries/WNScripting/src/WNCTranslator.cpp
+++ b/Libraries/WNScripting/src/WNCTranslator.cpp
@@ -71,6 +71,7 @@ c_translator::c_translator(memory::allocator* _allocator,
       external_function{"_call_actor_function",
           containers::dynamic_array<const ast_type*>(
               m_allocator, {m_type_manager.void_t(nullptr),
+                               m_type_manager.integral(32, nullptr),
                                m_type_manager.void_ptr_t(nullptr)})},
       true, false);
 

--- a/Libraries/WNScripting/src/WNJITEngine.cpp
+++ b/Libraries/WNScripting/src/WNJITEngine.cpp
@@ -118,9 +118,9 @@ void do_free_actor(void* a) {
   get_scripting_tls()->_runtime->free_actor(reinterpret_cast<actor_header*>(a));
 }
 
-void call_actor_function(void* a) {
+void call_actor_function(int32_t delay, void* a) {
   get_scripting_tls()->_runtime->call_actor_function(
-      reinterpret_cast<actor_function*>(a));
+      delay, reinterpret_cast<actor_function*>(a));
 }
 
 // Temp this is going to have to change.

--- a/Libraries/WNScripting/src/add_builtins.cpp
+++ b/Libraries/WNScripting/src/add_builtins.cpp
@@ -52,7 +52,7 @@ bool type_manager::add_builtin_functions() {
     return false;
   }
   if (m_externals_by_name.find(containers::string(m_allocator,
-          "_ZN3wns20_call_actor_functionEvPv")) == m_externals_by_name.end()) {
+          "_ZN3wns20_call_actor_functionEviPv")) == m_externals_by_name.end()) {
     m_log->log_error("External function _call_actor_function");
     return false;
   }
@@ -60,7 +60,7 @@ bool type_manager::add_builtin_functions() {
       m_externals_by_name["_ZN3wns20_allocate_actor_callEPvN3wns4sizeE"];
   m_free_actor_call = m_externals_by_name["_ZN3wns16_free_actor_callEvPv"];
   m_call_actor_function =
-      m_externals_by_name["_ZN3wns20_call_actor_functionEvPv"];
+      m_externals_by_name["_ZN3wns20_call_actor_functionEviPv"];
   add_allocate_shared();
   add_release_shared();
   add_assign_shared();

--- a/Libraries/WNScripting/src/convert_function_to_ast.cpp
+++ b/Libraries/WNScripting/src/convert_function_to_ast.cpp
@@ -85,203 +85,360 @@ parse_ast_convertor::convertor_context::pre_resolve_function(
       core::move(types), &m_used_types);
 
   if (_function->is_action()) {
-    auto callee_def =
-        memory::make_unique<struct_definition>(m_allocator, m_allocator,
-            (containers::string(m_allocator, "__") + fn->m_mangled_name +
-                "__call_params")
-                .c_str(),
-            false, nullptr);
-    callee_def->copy_location_from(_function->get_signature());
-    callee_def->set_is_actor_callee(true);
-    auto constructor_params =
-        memory::make_unique<parameter_list>(m_allocator, m_allocator);
-    constructor_params->copy_location_from(_function->get_signature());
+    {  // callee function AND callee struct
+      auto callee_def =
+          memory::make_unique<struct_definition>(m_allocator, m_allocator,
+              (containers::string(m_allocator, "__") + fn->m_mangled_name +
+                  "__call_params")
+                  .c_str(),
+              false, nullptr);
+      callee_def->copy_location_from(_function->get_signature());
+      callee_def->set_is_actor_callee(true);
+      auto constructor_params =
+          memory::make_unique<parameter_list>(m_allocator, m_allocator);
+      constructor_params->copy_location_from(_function->get_signature());
 
-    if (!m_type_manager->register_struct_definition(callee_def.get())) {
-      callee_def->log_line(m_log, logging::log_level::error);
-      return nullptr;
-    }
+      if (!m_type_manager->register_struct_definition(callee_def.get())) {
+        callee_def->log_line(m_log, logging::log_level::error);
+        return nullptr;
+      }
 
-    {
-      auto decl = memory::make_unique<declaration>(m_allocator, m_allocator);
-      decl->copy_location_from(_function->get_signature());
-      auto fnp_type = memory::make_unique<type>(
-          m_allocator, m_allocator, type_classification::function_ptr_type);
-      fnp_type->copy_location_from(_function);
-      fnp_type->set_reference_type(reference_type::raw);
-
-      auto this_param = memory::make_unique<parameter>(
-          m_allocator, m_allocator, core::move(fnp_type), "_fn");
-      this_param->copy_location_from(_function->get_signature());
-      decl->set_parameter(core::move(this_param));
-      auto construct_param = memory::make_unique<parameter>(m_allocator,
-          m_allocator, clone_node(m_allocator, decl->get_type()), "__fn");
-      construct_param->copy_location_from(_function->get_signature());
-      constructor_params->add_parameter(core::move(construct_param));
-
-      auto ex =
-          memory::make_unique<id_expression>(m_allocator, m_allocator, "__fn");
-      ex->copy_location_from(_function->get_signature());
-      decl->add_expression_initializer(core::move(ex));
-      callee_def->add_struct_elem(core::move(decl), false);
-    }
-
-    {
-      auto decl = memory::make_unique<declaration>(m_allocator, m_allocator);
-      decl->copy_location_from(_function->get_signature());
-      auto this_type = memory::make_unique<type>(
-          m_allocator, m_allocator, _implicit_this->m_name.c_str());
-      this_type->copy_location_from(_function);
-      this_type->set_reference_type(reference_type::raw);
-      auto this_param = memory::make_unique<parameter>(
-          m_allocator, m_allocator, core::move(this_type), "__this");
-      this_param->copy_location_from(_function->get_signature());
-      decl->set_parameter(core::move(this_param));
-      auto construct_param = memory::make_unique<parameter>(m_allocator,
-          m_allocator, clone_node(m_allocator, decl->get_type()), "___this");
-
-      construct_param->copy_location_from(_function->get_signature());
-      constructor_params->add_parameter(core::move(construct_param));
-
-      auto ex = memory::make_unique<id_expression>(
-          m_allocator, m_allocator, "___this");
-      ex->copy_location_from(_function->get_signature());
-      decl->add_expression_initializer(core::move(ex));
-      callee_def->add_struct_elem(core::move(decl), false);
-    }
-
-    for (auto& it : _function->get_parameters()->get_parameters()) {
-      auto decl = memory::make_unique<declaration>(m_allocator, m_allocator);
-      decl->copy_location_from(_function->get_signature());
-      auto parm = memory::make_unique<parameter>(m_allocator, m_allocator,
-          clone_node(m_allocator, it->get_type()),
-          (containers::string(m_allocator, "_") +
-              it->get_name().to_string(m_allocator))
-              .c_str());
-      parm->copy_location_from(_function->get_signature());
-      decl->set_parameter(core::move(parm));
-
-      auto construct_param = memory::make_unique<parameter>(m_allocator,
-          m_allocator, clone_node(m_allocator, it->get_type()),
-          (containers::string(m_allocator, "__") +
-              it->get_name().to_string(m_allocator))
-              .c_str());
-      construct_param->copy_location_from(_function->get_signature());
-      constructor_params->add_parameter(core::move(construct_param));
-
-      auto ex = memory::make_unique<id_expression>(m_allocator, m_allocator,
-          (containers::string(m_allocator, "__") +
-              it->get_name().to_string(m_allocator))
-              .c_str());
-      ex->copy_location_from(_function->get_signature());
-      decl->add_expression_initializer(core::move(ex));
-      callee_def->add_struct_elem(core::move(decl), false);
-    }
-    callee_def->set_constructor_parameters(core::move(constructor_params));
-    fn->m_action_call_type = walk_struct_definition(callee_def.get());
-    if (!fn->m_action_call_type) {
-      return nullptr;
-    }
-
-    auto insts =
-        memory::make_unique<instruction_list>(m_allocator, m_allocator);
-    insts->copy_location_from(_function->get_signature());
-    {
-      // _this
-      auto idexpr =
-          memory::make_unique<id_expression>(m_allocator, m_allocator, "_this");
-      idexpr->copy_location_from(_function->get_signature());
-      // _this->__this
-      auto macc = memory::make_unique<member_access_expression>(
-          m_allocator, m_allocator, "__this");
-      macc->copy_location_from(_function->get_signature());
-      macc->add_base_expression(clone_node(m_allocator, idexpr.get()));
-
-      // _this->__this-><function>
-      auto fnacc = memory::make_unique<member_access_expression>(
-          m_allocator, m_allocator, _function->get_signature()->get_name());
-      fnacc->copy_location_from(_function->get_signature());
-      fnacc->add_base_expression(core::move(macc));
-
-      auto al = memory::make_unique<arg_list>(m_allocator, m_allocator);
-      al->copy_location_from(_function->get_signature());
       {
-        for (auto& it : _function->get_parameters()->get_parameters()) {
-          auto param_expr = memory::make_unique<id_expression>(
-              m_allocator, m_allocator, "_this");
-          param_expr->copy_location_from(_function->get_signature());
+        auto decl = memory::make_unique<declaration>(m_allocator, m_allocator);
+        decl->copy_location_from(_function->get_signature());
+        auto fnp_type = memory::make_unique<type>(
+            m_allocator, m_allocator, type_classification::function_ptr_type);
+        fnp_type->copy_location_from(_function);
+        fnp_type->set_reference_type(reference_type::raw);
 
-          auto param_macc = memory::make_unique<member_access_expression>(
-              m_allocator, m_allocator,
-              containers::string(m_allocator, "_") + it->get_name_str());
-          param_macc->copy_location_from(_function->get_signature());
-          param_macc->add_base_expression(core::move(param_expr));
-          al->add_expression(core::move(param_macc));
+        auto this_param = memory::make_unique<parameter>(
+            m_allocator, m_allocator, core::move(fnp_type), "_fn");
+        this_param->copy_location_from(_function->get_signature());
+        decl->set_parameter(core::move(this_param));
+        auto construct_param = memory::make_unique<parameter>(m_allocator,
+            m_allocator, clone_node(m_allocator, decl->get_type()), "__fn");
+        construct_param->copy_location_from(_function->get_signature());
+        constructor_params->add_parameter(core::move(construct_param));
+
+        auto ex = memory::make_unique<id_expression>(
+            m_allocator, m_allocator, "__fn");
+        ex->copy_location_from(_function->get_signature());
+        decl->add_expression_initializer(core::move(ex));
+        callee_def->add_struct_elem(core::move(decl), false);
+      }
+
+      {
+        auto decl = memory::make_unique<declaration>(m_allocator, m_allocator);
+        decl->copy_location_from(_function->get_signature());
+        auto this_type = memory::make_unique<type>(
+            m_allocator, m_allocator, _implicit_this->m_name.c_str());
+        this_type->copy_location_from(_function);
+        this_type->set_reference_type(reference_type::raw);
+        auto this_param = memory::make_unique<parameter>(
+            m_allocator, m_allocator, core::move(this_type), "__this");
+        this_param->copy_location_from(_function->get_signature());
+        decl->set_parameter(core::move(this_param));
+        auto construct_param = memory::make_unique<parameter>(m_allocator,
+            m_allocator, clone_node(m_allocator, decl->get_type()), "___this");
+
+        construct_param->copy_location_from(_function->get_signature());
+        constructor_params->add_parameter(core::move(construct_param));
+
+        auto ex = memory::make_unique<id_expression>(
+            m_allocator, m_allocator, "___this");
+        ex->copy_location_from(_function->get_signature());
+        decl->add_expression_initializer(core::move(ex));
+        callee_def->add_struct_elem(core::move(decl), false);
+      }
+
+      for (auto& it : _function->get_parameters()->get_parameters()) {
+        auto decl = memory::make_unique<declaration>(m_allocator, m_allocator);
+        decl->copy_location_from(_function->get_signature());
+        auto parm = memory::make_unique<parameter>(m_allocator, m_allocator,
+            clone_node(m_allocator, it->get_type()),
+            (containers::string(m_allocator, "_") +
+                it->get_name().to_string(m_allocator))
+                .c_str());
+        parm->copy_location_from(_function->get_signature());
+        decl->set_parameter(core::move(parm));
+
+        auto construct_param = memory::make_unique<parameter>(m_allocator,
+            m_allocator, clone_node(m_allocator, it->get_type()),
+            (containers::string(m_allocator, "__") +
+                it->get_name().to_string(m_allocator))
+                .c_str());
+        construct_param->copy_location_from(_function->get_signature());
+        constructor_params->add_parameter(core::move(construct_param));
+
+        auto ex = memory::make_unique<id_expression>(m_allocator, m_allocator,
+            (containers::string(m_allocator, "__") +
+                it->get_name().to_string(m_allocator))
+                .c_str());
+        ex->copy_location_from(_function->get_signature());
+        decl->add_expression_initializer(core::move(ex));
+        callee_def->add_struct_elem(core::move(decl), false);
+      }
+      callee_def->set_constructor_parameters(core::move(constructor_params));
+      fn->m_action_call_type = walk_struct_definition(callee_def.get());
+      if (!fn->m_action_call_type) {
+        return nullptr;
+      }
+
+      auto insts =
+          memory::make_unique<instruction_list>(m_allocator, m_allocator);
+      insts->copy_location_from(_function->get_signature());
+      {
+        // _this
+        auto idexpr = memory::make_unique<id_expression>(
+            m_allocator, m_allocator, "_this");
+        idexpr->copy_location_from(_function->get_signature());
+        // _this->__this
+        auto macc = memory::make_unique<member_access_expression>(
+            m_allocator, m_allocator, "__this");
+        macc->copy_location_from(_function->get_signature());
+        macc->add_base_expression(clone_node(m_allocator, idexpr.get()));
+
+        // _this->__this-><function>
+        auto fnacc = memory::make_unique<member_access_expression>(
+            m_allocator, m_allocator, _function->get_signature()->get_name());
+        fnacc->copy_location_from(_function->get_signature());
+        fnacc->add_base_expression(core::move(macc));
+
+        auto al = memory::make_unique<arg_list>(m_allocator, m_allocator);
+        al->copy_location_from(_function->get_signature());
+        {
+          for (auto& it : _function->get_parameters()->get_parameters()) {
+            auto param_expr = memory::make_unique<id_expression>(
+                m_allocator, m_allocator, "_this");
+            param_expr->copy_location_from(_function->get_signature());
+
+            auto param_macc = memory::make_unique<member_access_expression>(
+                m_allocator, m_allocator,
+                containers::string(m_allocator, "_") + it->get_name_str());
+            param_macc->copy_location_from(_function->get_signature());
+            param_macc->add_base_expression(core::move(param_expr));
+            al->add_expression(core::move(param_macc));
+          }
+        }
+
+        auto fn_call = memory::make_unique<function_call_expression>(
+            m_allocator, m_allocator, core::move(al));
+        fn_call->copy_location_from(_function->get_signature());
+        fn_call->add_base_expression(core::move(fnacc));
+
+        auto expr_inst = memory::make_unique<expression_instruction>(
+            m_allocator, m_allocator, core::move(fn_call));
+        expr_inst->copy_location_from(_function->get_signature());
+        insts->add_instruction(core::move(expr_inst));
+
+        auto param_expr = memory::make_unique<id_expression>(
+            m_allocator, m_allocator, "_this");
+        param_expr->copy_location_from(_function->get_signature());
+        al = memory::make_unique<arg_list>(m_allocator, m_allocator);
+        al->copy_location_from(_function->get_signature());
+        al->add_expression(core::move(param_expr));
+
+        auto new_id_expr = memory::make_unique<id_expression>(
+            m_allocator, m_allocator, "_free_actor_call");
+        new_id_expr->copy_location_from(_function->get_signature());
+
+        fn_call = memory::make_unique<function_call_expression>(
+            m_allocator, m_allocator, core::move(al));
+        fn_call->copy_location_from(_function->get_signature());
+        fn_call->add_base_expression(core::move(new_id_expr));
+
+        expr_inst = memory::make_unique<expression_instruction>(
+            m_allocator, m_allocator, core::move(fn_call));
+        expr_inst->copy_location_from(_function->get_signature());
+        insts->add_instruction(core::move(expr_inst));
+      }
+
+      auto struct_callee_type = memory::make_unique<type>(
+          m_allocator, m_allocator, fn->m_action_call_type->m_name.c_str());
+      struct_callee_type->copy_location_from(_function);
+      struct_callee_type->set_reference_type(reference_type::unique);
+
+      auto param = memory::make_unique<parameter>(
+          m_allocator, m_allocator, core::move(struct_callee_type), "_this");
+      param->copy_location_from(_function->get_signature());
+      auto param_list = memory::make_unique<parameter_list>(
+          m_allocator, m_allocator, core::move(param));
+      param_list->copy_location_from(_function->get_signature());
+
+      auto sig = memory::make_unique<parameter>(m_allocator, m_allocator,
+          clone_node(m_allocator, _function->get_signature()->get_type()),
+          (containers::string(m_allocator, "__call_") +
+              _function->get_signature()->get_name_str())
+              .c_str());
+
+      auto af = memory::make_unique<function>(m_allocator, m_allocator,
+          core::move(sig), core::move(param_list), core::move(insts));
+      af->copy_location_from(_function->get_signature());
+
+      auto ah = pre_resolve_function(af.get(), nullptr);
+      ah->m_is_action_caller = true;
+      if (!ah) {
+        return nullptr;
+      }
+      m_action_helpers_parse.push_back(core::move(af));
+      fn->m_action_function = ah.get();
+      m_action_helpers.push_back(core::move(ah));
+    }
+
+    {
+      memory::unique_ptr<ast_function> new_fn =
+          memory::make_unique<ast_function>(m_allocator, _function);
+
+      // Hopefully still void
+      new_fn->m_return_type = ret_ty;
+      if (!new_fn->m_return_type) {
+        return nullptr;
+      }
+      new_fn->m_name =
+          containers::string(m_allocator, "__call__action__") +
+          _function->get_signature()->get_name().to_string(m_allocator);
+      containers::string new_mangled_name(m_allocator);
+      containers::dynamic_array<const ast_type*> new_types(m_allocator);
+      new_types.push_back(ret_ty);
+      auto it = m_named_functions.find(new_fn->m_name);
+      if (it == m_named_functions.end()) {
+        it = m_named_functions
+                 .insert(core::make_pair(new_fn->m_name,
+                     containers::deque<const ast_function*>(m_allocator)))
+                 .first;
+      }
+      it->second.push_back(new_fn.get());
+
+      containers::deque<ast_function::parameter>& new_function_params =
+          new_fn->initialized_parameters(m_allocator);
+      new_function_params.push_back(
+          ast_function::parameter{containers::string(m_allocator, "_count"),
+              fn.get(), m_type_manager->integral(32, &m_used_types)});
+      new_function_params.push_back(ast_function::parameter{
+          containers::string(m_allocator, "_this"), fn.get(), _implicit_this});
+
+      if (_function->get_parameters() &&
+          _function->get_parameters()->get_parameters().size()) {
+        for (auto& param : _function->get_parameters()->get_parameters()) {
+          const ast_type* param_type = resolve_type(param->get_type());
+          if (!param_type) {
+            return nullptr;
+          }
+          new_types.push_back(param_type);
+          new_function_params.push_back(ast_function::parameter{
+              containers::string(m_allocator, param->get_name()), fn.get(),
+              param_type});
         }
       }
 
-      auto fn_call = memory::make_unique<function_call_expression>(
-          m_allocator, m_allocator, core::move(al));
-      fn_call->copy_location_from(_function->get_signature());
-      fn_call->add_base_expression(core::move(fnacc));
+      new_fn->m_is_virtual = false;
+      new_fn->m_is_override = false;
+      new_fn->m_is_synchronized = false;
+      new_fn->m_is_member_function = false;
+      new_fn->calculate_mangled_name(m_allocator);
+      new_fn->m_function_pointer_type =
+          m_type_manager->resolve_function_ptr_type(
+              core::move(new_types), &m_used_types);
 
-      auto expr_inst = memory::make_unique<expression_instruction>(
-          m_allocator, m_allocator, core::move(fn_call));
-      expr_inst->copy_location_from(_function->get_signature());
-      insts->add_instruction(core::move(expr_inst));
+      new_fn->m_scope =
+          memory::make_unique<ast_scope_block>(m_allocator, _function);
 
-      auto param_expr =
-          memory::make_unique<id_expression>(m_allocator, m_allocator, "_this");
-      param_expr->copy_location_from(_function->get_signature());
-      al = memory::make_unique<arg_list>(m_allocator, m_allocator);
-      al->copy_location_from(_function->get_signature());
-      al->add_expression(core::move(param_expr));
+      auto& statements = new_fn->m_scope->initialized_statements(m_allocator);
+      // We are invoking an action on a different actor,
+      // then instead of
+      // foo->bar(a, b, c);
+      // we instead call
+      //
+      // external_actor_act(__foo__bar__call_params_construct(external_get_call_param_mem(sizeof(__foo__bar__call_params)),
+      // foo, bar, a, b, c))
 
-      auto new_id_expr = memory::make_unique<id_expression>(
-          m_allocator, m_allocator, "_free_actor_call");
-      new_id_expr->copy_location_from(_function->get_signature());
+      auto num_bytes =
+          memory::make_unique<ast_builtin_expression>(m_allocator, _function);
+      num_bytes->m_type = m_type_manager->size_t_t(&m_used_types);
+      num_bytes->initialized_extra_types(m_allocator)
+          .push_back(fn->m_action_call_type);
+      num_bytes->m_builtin_type = builtin_expression_type::size_of;
 
-      fn_call = memory::make_unique<function_call_expression>(
-          m_allocator, m_allocator, core::move(al));
-      fn_call->copy_location_from(_function->get_signature());
-      fn_call->add_base_expression(core::move(new_id_expr));
+      auto alloc_call = memory::make_unique<ast_function_call_expression>(
+          m_allocator, _function);
+      alloc_call->m_function =
+          m_type_manager->allocate_actor_call(&m_used_externals);
+      alloc_call->initialized_parameters(m_allocator)
+          .push_back(core::move(num_bytes));
+      alloc_call->m_type = alloc_call->m_function->m_return_type;
 
-      expr_inst = memory::make_unique<expression_instruction>(
-          m_allocator, m_allocator, core::move(fn_call));
-      expr_inst->copy_location_from(_function->get_signature());
-      insts->add_instruction(core::move(expr_inst));
+      auto constructor_call = memory::make_unique<ast_function_call_expression>(
+          m_allocator, _function);
+      constructor_call->m_function = fn->m_action_call_type->m_constructor;
+      // constructor_call->m_parameters =
+      // core::move(function_call->m_parameters);
+
+      auto function_call = memory::make_unique<ast_function_call_expression>(
+          m_allocator, _function);
+      function_call->m_type = ret_ty;
+      WN_DEBUG_ASSERT(ret_ty == m_type_manager->void_t(nullptr),
+          "Expected return type to be void for action");
+
+      auto& params = constructor_call->initialized_parameters(m_allocator);
+
+      {
+        // The count doesn't go down to the allocator.
+        bool first = true;
+        for (auto& x : new_function_params) {
+          if (first) {
+            first = false;
+            continue;
+          }
+          auto ide = memory::make_unique<ast_id>(m_allocator, _function);
+          ide->m_type = x.m_type;
+          ide->m_function_parameter = &x;
+          params.push_back(core::move(ide));
+        }
+      }
+
+      auto fn_ptr = memory::make_unique<ast_function_pointer_expression>(
+          m_allocator, _function);
+      fn_ptr->m_function = fn->m_action_function;
+      fn_ptr->m_type = fn->m_action_function->m_function_pointer_type;
+
+      auto fn_ptr_as_void =
+          memory::make_unique<ast_cast_expression>(m_allocator, _function);
+      fn_ptr_as_void->m_type = m_type_manager->function_t(&m_used_types);
+      fn_ptr_as_void->m_base_expression = core::move(fn_ptr);
+
+      constructor_call->m_parameters.push_front(core::move(fn_ptr_as_void));
+      constructor_call->m_parameters.push_front(
+          make_cast(core::move(alloc_call),
+              m_type_manager->get_reference_of(fn->m_action_call_type,
+                  ast_type_classification::reference, &m_used_types)));
+      constructor_call->m_type = constructor_call->m_function->m_return_type;
+
+      function_call->m_function =
+          m_type_manager->call_actor_function(&m_used_builtins);
+
+      auto& nps = function_call->initialized_parameters(m_allocator);
+      {
+        auto ide = memory::make_unique<ast_id>(m_allocator, _function);
+        ide->m_type = new_function_params[0].m_type;
+        ide->m_function_parameter = &new_function_params[0];
+        nps.push_back(core::move(ide));
+      }
+
+      {
+        nps.push_back(make_cast(core::move(constructor_call),
+            function_call->m_function->m_parameters[1].m_type));
+      }
+
+      auto statement =
+          memory::make_unique<ast_evaluate_expression>(m_allocator, _function);
+      statement->m_expr = core::move(function_call);
+      statements.push_back(core::move(statement));
+
+      statements.push_back(
+          memory::make_unique<ast_return_instruction>(m_allocator, _function));
+      fn->m_action_call_function = new_fn.get();
+      m_action_helpers.push_back(core::move(new_fn));
     }
-
-    auto struct_callee_type = memory::make_unique<type>(
-        m_allocator, m_allocator, fn->m_action_call_type->m_name.c_str());
-    struct_callee_type->copy_location_from(_function);
-    struct_callee_type->set_reference_type(reference_type::unique);
-
-    auto param = memory::make_unique<parameter>(
-        m_allocator, m_allocator, core::move(struct_callee_type), "_this");
-    param->copy_location_from(_function->get_signature());
-    auto param_list = memory::make_unique<parameter_list>(
-        m_allocator, m_allocator, core::move(param));
-    param_list->copy_location_from(_function->get_signature());
-
-    auto sig = memory::make_unique<parameter>(m_allocator, m_allocator,
-        clone_node(m_allocator, _function->get_signature()->get_type()),
-        (containers::string(m_allocator, "__call_") +
-            _function->get_signature()->get_name_str())
-            .c_str());
-
-    auto af = memory::make_unique<function>(m_allocator, m_allocator,
-        core::move(sig), core::move(param_list), core::move(insts));
-    af->copy_location_from(_function->get_signature());
-
-    auto ah = pre_resolve_function(af.get(), nullptr);
-    ah->m_is_action_caller = true;
-    if (!ah) {
-      return nullptr;
-    }
-    m_action_helpers_parse.push_back(core::move(af));
-    fn->m_action_function = ah.get();
-    m_action_helpers.push_back(core::move(ah));
   }
 
   return fn;

--- a/Libraries/WNScripting/src/convert_parse_to_ast.cpp
+++ b/Libraries/WNScripting/src/convert_parse_to_ast.cpp
@@ -214,6 +214,9 @@ bool parse_ast_convertor::convertor_context::walk_script_file(
         m_script_file->m_functions.push_back(
             core::move(m_action_helpers.back()));
         m_action_helpers.pop_back();
+        m_script_file->m_functions.push_back(
+            core::move(m_action_helpers.back()));
+        m_action_helpers.pop_back();
       }
       st_type->initialized_member_functions(m_allocator).push_back(fun.get());
       functions.push_back(core::make_pair(f.get(), fun.get()));

--- a/applications/editor/assets/ui/main.rml
+++ b/applications/editor/assets/ui/main.rml
@@ -4,63 +4,16 @@
     <link type="text/css" href="main.rcss"/>
 <script>
 // UIName=MainGUI
-@synchronized Void on_button_click(UiElement element) {
-   UiElement body = element.owner();
-
-   Int last_selection = body.get_first_child().get_int_attribute("current_tab_selected");
-   body.get_first_child().set_attribute("current_tab_selected", element.get_int_attribute("child_id"));
-
-   // Modify LastElement before current element in case 
-   // the user re-activates the current element.
-   UiElement last_element = body.get_first_child().get_first_child().get_child(last_selection); 
-   last_element.set_attribute(
-      "document_contents",
-      body.get_child(1).get_inner_rml().c_str()
-   );
-   last_element.set_class("passive_titlebar_item", true);
-   last_element.set_class("active_titlebar_item", false);
-   
-   body.get_child(1).set_inner_rml(
-      element.get_attribute("document_contents").c_str()
-   );
-   element.set_class("passive_titlebar_item", false);
-   element.set_class("active_titlebar_item", true);
+@synchronized Void on_button_click(CString id) {
+   log_error().o("Click: ").o(id).end();
 }
 
-@synchronized Void titlebar_onload(UiElement element) {
-   Int n_children = element.get_first_child().get_first_child().num_children();
-   element.get_first_child().set_attribute(
-      "titlebar_children",
-      n_children
-   );
-   element.get_first_child().set_attribute(
-      "current_tab_selected",
-      0
-   );
+@synchronized Void titlebar_onload(CString id) {
+   log_error().o("Update: ").o(id).end();
 
-   log_error().o("Hello World").end();
-   log_error().o("Titlebar Children").o(
-      element.get_first_child().get_int_attribute("titlebar_children")
-   ).end();
-   UiElement titlebar_contents = element.get_first_child().get_first_child();
-   for (Int i = 0; i < n_children; ++i) {
-      UiElement elem = titlebar_contents.get_child(i); 
-      if (i == 0) {
-         elem.set_attribute("document_contents", 
-            element.get_child(1).get_inner_rml().c_str()
-         );
-         elem.set_class("active_titlebar_item", true);
-      } else {
-         elem.set_attribute("document_contents", 
-            "Dummy dummy Dummy"
-         );
-         elem.set_class("passive_titlebar_item", true);
-      }
-      titlebar_contents.get_child(i).set_attribute("child_id", i);
-   }
 }
 @synchronized override Void update(Int doc_idx, UiDocument doc) {
-   log_error().o("Update: ").o(doc_idx).end();
+   
 }
 </script>
 </head>

--- a/applications/editor/assets/ui/window.rml
+++ b/applications/editor/assets/ui/window.rml
@@ -79,11 +79,12 @@ scrollbarhorizontal sliderbar
 </style>
 </head>
 <body onload="titlebar_onload" style="min-width:100px; min-height: 100px; width: 300px; height: 300px; display:block; position: absolute; background-color: #455A64;  border-color: gray; border-width: 3px; overflow: hidden;" class="window">
+	<handle move_target="#document" style="background-color: #CFD8DC; display:inline-block; width: 100%; height: 5px;"></handle>
 	<titlebar>
-	<titlebarcontents>
-	<titlebaritem onclick="this.on_button_click" >Hello</titlebaritem>
-	<titlebaritem onclick="this.on_button_click" >World</titlebaritem>
-	<titlebaritem onclick="this.on_button_click" >WorldWorldHello</titlebaritem>
+	<titlebarcontents id="titlebar">	
+	<titlebaritem onclick="this.on_button_click" id="1">Hello</titlebaritem>
+	<titlebaritem onclick="this.on_button_click" id="2">World</titlebaritem>
+	<titlebaritem onclick="this.on_button_click" id="3">WorldWorldHello</titlebaritem>
 	</titlebarcontents>
 	</titlebar>
 	<div id="window">

--- a/applications/script_test_runner/src/WNScriptTestRunner.cpp
+++ b/applications/script_test_runner/src/WNScriptTestRunner.cpp
@@ -293,7 +293,9 @@ public:
     return m_allocator->deallocate(actor);
   }
 
-  void call_actor_function(wn::scripting::actor_function* function) override {
+  void call_actor_function(
+      int32_t delay, wn::scripting::actor_function* function) override {
+    (void)delay;
     function->function(function);
   }
 

--- a/engine/engine_base/inc/context.h
+++ b/engine/engine_base/inc/context.h
@@ -32,7 +32,8 @@ public:
 
   scripting::actor_header* allocate_actor(size_t size) override;
   void free_actor(scripting::actor_header* actor) override;
-  void call_actor_function(scripting::actor_function* function) override;
+  void call_actor_function(
+      int32_t delay, scripting::actor_function* function) override;
 
 private:
   containers::hash_set<scripting::actor_header*> m_actors;

--- a/engine/engine_base/src/context.cpp
+++ b/engine/engine_base/src/context.cpp
@@ -47,7 +47,9 @@ void context::free_actor(scripting::actor_header* actor) {
   m_actors_to_delete.push_back(actor);
 }
 
-void context::call_actor_function(scripting::actor_function* function) {
+void context::call_actor_function(
+    int32_t delay, scripting::actor_function* function) {
+  (void)delay;
   auto eh = reinterpret_cast<engine_header*>(function->get_actor_header());
   size_t nv = eh->m_next_value++;
   m_application_data->default_job_pool->add_job(

--- a/engine/ui/inc/ui_scripting_event_instancer.h
+++ b/engine/ui/inc/ui_scripting_event_instancer.h
@@ -74,9 +74,8 @@ private:
   scripting::engine* m_engine;
   logging::log* m_log;
   scripting::script_actor_pointer<ui_data> m_ui_data;
-  wn::scripting::script_function<void, Rocket::Core::Element*> m_callee;
-  wn::scripting::script_function<void, void*, Rocket::Core::Element*>
-      m_member_callee;
+  wn::scripting::script_function<void, const char*> m_callee;
+  wn::scripting::script_function<void, void*, const char*> m_member_callee;
 };
 
 }  // namespace ui

--- a/engine/ui/src/ui_scripting_event_instancer.cpp
+++ b/engine/ui/src/ui_scripting_event_instancer.cpp
@@ -202,11 +202,11 @@ event_listener::~event_listener() {}
 
 void event_listener::ProcessEvent(Rocket::Core::Event& event) {
   if (m_callee) {
-    m_engine->invoke(m_callee, event.GetTargetElement());
+    m_engine->invoke(m_callee, event.GetTargetElement()->GetId().CString());
     return;
   } else if (m_member_callee) {
-    m_engine->invoke(
-        m_member_callee, m_ui_data.unsafe_ptr(), event.GetTargetElement());
+    m_engine->invoke(m_member_callee, m_ui_data.unsafe_ptr(),
+        event.GetTargetElement()->GetId().CString());
     return;
   }
   m_log->log_warning(


### PR DESCRIPTION
This simply creates an extra function that primes the actor call.

So instead of having to inject a bunch of actor related business at the call-site, we can now just call the wrapper function that actually handles allocating the actor data, and it acts like a "normal" function call.

Furthermore this sets us up for 2 things
  1) being able to defer an actor update until a future time
     (# of frames)
  2) Calling actions from C++. This will be important very soon
     as the UI model is firming up.