### PR TITLE
Adjust CI to use shared workflows

### DIFF
--- a/.build-ignore
+++ b/.build-ignore
@@ -2,6 +2,7 @@
 .gitattributes
 .github/CODEOWNERS
 .github/dependabot.yml
+.github/labeler.yml
 .github/labels.yml
 .github/workflows/sync-labels.yml
 .github/workflows/update-license.yml

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+documentation:
+  - '*.md'
+  - LICENSE
+github-actions:
+  - .github/workflows/*.yml
+submodules:
+  - any:
+      - externals/*
+    all:
+      - '!externals/CMakeLists.txt'
+      - '!externals/LICENSE.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         with:
           path: ./source
           submodules: true
-      - name: Set up gcs key
+      - name: Set up GCS key
         shell: bash
         run: echo "$GCS_KEY" > /tmp/gcs_key.json
         env:
@@ -375,7 +375,7 @@ jobs:
         with:
           path: ./source
           submodules: true
-      - name: Set up gcs key
+      - name: Set up GCS key
         shell: bash
         run: echo "$GCS_KEY" > /tmp/gcs_key.json
         env:
@@ -436,7 +436,7 @@ jobs:
         with:
           path: ./source
           submodules: true
-      - name: Set up gcs key
+      - name: Set up GCS key
         shell: bash
         run: echo "$GCS_KEY" > gcs_key.json
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,11 @@
 name: CI
 on:
-  pull_request:
-    branches: master
-  push:
-    branches: master
+  workflow_call:
 permissions:
   contents: read
-concurrency:
-  group: ci-${{github.ref}}
-  cancel-in-progress: ${{github.ref != 'refs/heads/master'}}
 jobs:
   analyze-changes:
-    name: Analyze changes
+    name: Analyze Changes
     timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
@@ -134,7 +128,7 @@ jobs:
           echo "$changes_md" >> $GITHUB_OUTPUT
           echo "$delimiter" >> $GITHUB_OUTPUT
   check-licenses:
-    name: Check licenses
+    name: Check Licenses
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-check-licenses == 'true'
     timeout-minutes: 5
@@ -251,7 +245,7 @@ jobs:
             exit 1
           fi
   check-formatting-c-cpp:
-    name: Check formatting (C/C++)
+    name: Check Formatting (C/C++)
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-format-check-c-cpp == 'true'
     timeout-minutes: 5
@@ -265,7 +259,7 @@ jobs:
           echo -n '${{needs.analyze-changes.outputs.changes-c-cpp}}' |
           xargs -0 clang-format --dry-run --Werror
   check-formatting-md:
-    name: Check formatting (Markdown)
+    name: Check Formatting (Markdown)
     needs: analyze-changes
     if: needs.analyze-changes.outputs.run-format-check-md == 'true'
     timeout-minutes: 5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,25 @@
+name: Pull Request
+on:
+  pull_request:
+    branches: master
+permissions:
+  contents: read
+concurrency:
+  group: pull-request-${{github.ref}}
+  cancel-in-progress: true
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v4.0.2
+        with:
+          repo-token: ${{github.token}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,11 @@
+name: Push
+on:
+  push:
+    branches: master
+concurrency: push
+permissions:
+  contents: read
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: Sync labels
+name: Sync Labels
 on:
   push:
     branches: master
@@ -11,7 +11,7 @@ permissions:
   issues: write
 jobs:
   sync-labels:
-    name: Sync labels
+    name: Sync Labels
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,4 +1,4 @@
-name: Update license
+name: Update License
 on:
   schedule:
     - cron: '0 0 1 1 *'
@@ -8,7 +8,7 @@ env:
   REGEX: ^(((\/\/|#) )?Copyright \(c\) )[0-9]{4}(, WNProject Authors(\. All rights reserved.)?)$
 jobs:
   update-license:
-    name: Update license
+    name: Update License
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This will allow us to have stuff that is specific to PR's and specific to merging into `master`. I also added PR labeling as an example of divergent execution steps (can add more rules as we desire, help with searching for PR's). Eventually want to pull the analyze changes stuff out into only the PR stuff since for integration we always want to run everything but PR's we want to run only stuff related to changes. If we ever do releases as well those would only be needed in the push to `master` or with tags. Will need tp update PR required checks for branch protection after this is good to go. I will probably also split out format checking and build into their own shared workflows. Will help with future maintenance since the files will be smaller.