### PR TITLE
Move `Analyze Changes` job out of `CI`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,136 +1,36 @@
 name: CI
 on:
   workflow_call:
+    inputs:
+      run-build:
+        required: true
+        type: boolean
+      run-check-licenses:
+        required: true
+        type: boolean
+      run-format-check-c-cpp:
+        required: true
+        type: boolean
+      run-format-check-md:
+        required: true
+        type: boolean
+      changes-externals:
+        required: false
+        type: string
+      changes-c-cpp:
+        required: false
+        default: '**/*.+(c|cpp|h|hpp|inl)'
+        type: string
+      changes-md:
+        required: false
+        default: '**/*.md'
+        type: string
 permissions:
   contents: read
 jobs:
-  analyze-changes:
-    name: Analyze Changes
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      run-build: ${{steps.analysis.outputs.run-build}}
-      run-check-licenses: ${{steps.analysis.outputs.run-check-licenses}}
-      run-format-check-c-cpp: ${{steps.analysis.outputs.run-format-check-c-cpp}}
-      run-format-check-md: ${{steps.analysis.outputs.run-format-check-md}}
-      changes-externals: ${{steps.analysis.outputs.changes-externals}}
-      changes-c-cpp: ${{steps.analysis.outputs.changes-c-cpp}}
-      changes-md: ${{steps.analysis.outputs.changes-md}}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-        with:
-          fetch-depth: 0
-      - name: Analyze changes
-        id: analysis
-        shell: bash
-        run: |
-          if [ "$GITHUB_REF" == 'refs/heads/master' ]; then
-            build=true
-            check_licenses=true
-            format_check_c_cpp=true
-            format_check_md=true
-            changes_externals=$(
-              find externals/ -mindepth 1 -maxdepth 1 \
-              -type f -iname LICENSE.* -or -type d -and -not -iname .patches |
-              cut -d. -f2 | cut -d/ -f2 | sort | uniq
-            )
-            changes_c_cpp=$(
-              find . -type f \
-              -iregex '^.*\.\(c\|cpp\|h\|hpp\|inl\)$' -and -not \
-              -iregex '^\.\/externals.*$' | sort
-            )
-            changes_md=$(find . -type f -iname '*.md' | sort)
-          else
-            build_ignore=()
-            while IFS= read -r line || [[ "$line" ]]; do
-              build_ignore+=(':!'"$line")
-            done < .build-ignore
-            build_changes=$(
-              git diff --name-status origin/master HEAD -- ${build_ignore[@]} |
-              sort
-            )
-            if [ -z "$build_changes" ]; then
-              build=false
-            else
-              build=true
-            fi
-            changes_externals=$(
-              git diff --name-only origin/master HEAD -- \
-              externals/ ':!externals/CMakeLists.txt' ':!externals/*/*' |
-              cut -d. -f2 | cut -d/ -f2 | sort | uniq
-            )
-            if [ -z "$changes_externals" ]; then
-              check_licenses=false
-            else
-              check_licenses=true
-            fi
-            changes_c_cpp=$(
-              git diff --diff-filter=d --name-only origin/master HEAD -- \
-              ':!externals/*/*' '*.c' '*.cpp' '*.h' '*.hpp' '*.inl' \
-              .clang-format
-            )
-            if [ -z "$changes_c_cpp" ]; then
-              format_check_c_cpp=false
-            else
-              format_check_c_cpp=true
-              changes_c_cpp=$(
-                echo "$changes_c_cpp" | grep -v .clang-format || true | sort
-              )
-            fi
-            changes_md=$(
-              git diff --diff-filter=d --name-only origin/master HEAD -- \
-              '*.md' .markdownlintrc .markdownlintignore
-            )
-            if [ -z "$changes_md" ]; then
-              format_check_md=false
-            else
-              format_check_md=true
-              changes_md=$(
-                echo "$changes_md" | grep -v .markdownlint || true | sort
-              )
-            fi
-          fi
-          echo "Run build: $build"
-          echo "Run license check: $check_licenses"
-          echo "Run format check (C/C++): $format_check_c_cpp"
-          echo "Run format check (Markdown): $format_check_md"
-          if [ -z "$build_changes" ]; then
-            echo 'Changes affecting build: [none]'
-          else
-            echo -e "Changes affecting build:\n$build_changes"
-          fi
-          if [ -z "$changes_externals" ]; then
-            echo 'Changes (Externals): [none]'
-          else
-            echo -e "Changes (Externals):\n$changes_externals"
-          fi
-          if [ -z "$changes_c_cpp" ]; then
-            echo 'Changes (C/C++): [none]'
-          else
-            echo -e "Changes (C/C++):\n$changes_c_cpp"
-          fi
-          if [ -z "$changes_md" ]; then
-            echo 'Changes (Markdown): [none]'
-          else
-            echo -e "Changes (Markdown):\n$changes_md"
-          fi
-          changes_externals=${changes_externals//$'\n'/'\0'}
-          changes_c_cpp=${changes_c_cpp//$'\n'/'\0'}
-          delimiter=$(head -c 16 /dev/urandom | base64)
-          echo "run-build=$build" >> $GITHUB_OUTPUT
-          echo "run-check-licenses=$check_licenses" >> $GITHUB_OUTPUT
-          echo "run-format-check-c-cpp=$format_check_c_cpp" >> $GITHUB_OUTPUT
-          echo "run-format-check-md=$format_check_md" >> $GITHUB_OUTPUT
-          echo "changes-externals=$changes_externals" >> $GITHUB_OUTPUT
-          echo "changes-c-cpp=$changes_c_cpp" >> $GITHUB_OUTPUT
-          echo "changes-md<<$delimiter" >> $GITHUB_OUTPUT
-          echo "$changes_md" >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
   check-licenses:
     name: Check Licenses
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-check-licenses == 'true'
+    if: inputs.run-check-licenses
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -140,8 +40,16 @@ jobs:
           submodules: true
       - name: Check external licenses
         run: |
-          externals='${{needs.analyze-changes.outputs.changes-externals}}'
-          externals=${externals//'\0'/$'\n'}
+          if [ -z "$INPUTS_CHANGES" ]; then
+            externals=$(
+              find externals/ -mindepth 1 -maxdepth 1 \
+              -type f -iname LICENSE.* -or -type d -and -not -iname .patches |
+              cut -d. -f2 | cut -d/ -f2 | sort | uniq
+            )
+          else
+            externals="$INPUTS_CHANGES"
+            externals=${externals//'\0'/$'\n'}
+          fi
           ignore_list=(
             librocket
           )
@@ -244,10 +152,11 @@ jobs:
           if ! $result; then
             exit 1
           fi
+        env:
+          INPUTS_CHANGES: ${{inputs.changes-externals}}
   check-formatting-c-cpp:
     name: Check Formatting (C/C++)
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-format-check-c-cpp == 'true'
+    if: inputs.run-format-check-c-cpp
     timeout-minutes: 5
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/clang-format
@@ -255,13 +164,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Check formatting
-        run: echo -n "$INPUT_CHANGES" | xargs -0 clang-format --dry-run --Werror
+        shell: bash
+        run: |
+          shopt -s extglob globstar nullglob
+          echo "$INPUTS_CHANGES" | xargs clang-format --dry-run --Werror
         env:
-          INPUT_CHANGES: ${{needs.analyze-changes.outputs.changes-c-cpp}}
+          INPUTS_CHANGES: ${{inputs.changes-c-cpp}}
   check-formatting-md:
     name: Check Formatting (Markdown)
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-format-check-md == 'true'
+    if: inputs.run-format-check-md
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -270,11 +181,10 @@ jobs:
       - name: Check formatting
         uses: davidanson/markdownlint-cli2-action@v6.0.0
         with:
-          globs: ${{needs.analyze-changes.outputs.changes-md}}
+          globs: ${{inputs.changes-md}}
   build-android:
     name: Build Android
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-build == 'true'
+    if: inputs.run-build
     timeout-minutes: 90
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-android
@@ -350,8 +260,7 @@ jobs:
         run: du -hbcs ./source ./build
   build-linux:
     name: Build Linux
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-build == 'true'
+    if: inputs.run-build
     timeout-minutes: 90
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-linux:${{matrix.compiler}}
@@ -411,8 +320,7 @@ jobs:
         run: du -hbcs ./source ./build
   build-windows:
     name: Build Windows
-    needs: analyze-changes
-    if: needs.analyze-changes.outputs.run-build == 'true'
+    if: inputs.run-build
     timeout-minutes: 90
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,9 +6,6 @@ concurrency:
   group: pull-request-${{github.ref}}
   cancel-in-progress: true
 jobs:
-  ci:
-    name: CI
-    uses: ./.github/workflows/ci.yml
   label:
     name: Label
     runs-on: ubuntu-latest
@@ -21,3 +18,121 @@ jobs:
         uses: actions/labeler@v4.0.2
         with:
           repo-token: ${{github.token}}
+  analyze-changes:
+    name: Analyze Changes
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      run-build: ${{steps.analyze-changes.outputs.run-build}}
+      run-check-licenses: ${{steps.analyze-changes.outputs.run-check-licenses}}
+      run-format-check-c-cpp: ${{steps.analyze-changes.outputs.run-format-check-c-cpp}}
+      run-format-check-md: ${{steps.analyze-changes.outputs.run-format-check-md}}
+      changes-externals: ${{steps.analyze-changes.outputs.changes-externals}}
+      changes-c-cpp: ${{steps.analyze-changes.outputs.changes-c-cpp}}
+      changes-md: ${{steps.analyze-changes.outputs.changes-md}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - name: Analyze changes
+        id: analyze-changes
+        shell: bash
+        run: |
+          build_ignore=()
+          while IFS= read -r line || [[ "$line" ]]; do
+            build_ignore+=(':!'"$line")
+          done < .build-ignore
+          build_changes=$(
+            git diff --name-status origin/master HEAD -- ${build_ignore[@]} |
+            sort
+          )
+          if [ -z "$build_changes" ]; then
+            build=false
+          else
+            build=true
+          fi
+          changes_externals=$(
+            git diff --name-only origin/master HEAD -- \
+            externals/ ':!externals/CMakeLists.txt' ':!externals/*/*' |
+            cut -d. -f2 | cut -d/ -f2 | sort | uniq
+          )
+          if [ -z "$changes_externals" ]; then
+            check_licenses=false
+          else
+            check_licenses=true
+          fi
+          changes_c_cpp=$(
+            git diff --diff-filter=d --name-only origin/master HEAD -- \
+            '*.c' '*.cpp' '*.h' '*.hpp' '*.inl' .clang-format
+          )
+          if [ -z "$changes_c_cpp" ]; then
+            format_check_c_cpp=false
+          else
+            format_check_c_cpp=true
+            changes_c_cpp=$(
+              echo "$changes_c_cpp" | grep -v .clang-format || true | sort
+            )
+          fi
+          changes_md=$(
+            git diff --diff-filter=d --name-only origin/master HEAD -- \
+            '*.md' .markdownlintrc .markdownlintignore
+          )
+          if [ -z "$changes_md" ]; then
+            format_check_md=false
+          else
+            format_check_md=true
+            changes_md=$(
+              echo "$changes_md" | grep -v .markdownlint || true | sort
+            )
+          fi
+          echo "Run build: $build"
+          echo "Run license check: $check_licenses"
+          echo "Run format check (C/C++): $format_check_c_cpp"
+          echo "Run format check (Markdown): $format_check_md"
+          if [ -z "$build_changes" ]; then
+            echo 'Changes affecting build: [none]'
+          else
+            echo -e "Changes affecting build:\n$build_changes"
+          fi
+          if [ -z "$changes_externals" ]; then
+            echo 'Changes (Externals): [none]'
+          else
+            echo -e "Changes (Externals):\n$changes_externals"
+          fi
+          if [ -z "$changes_c_cpp" ]; then
+            echo 'Changes (C/C++): [none]'
+          else
+            echo -e "Changes (C/C++):\n$changes_c_cpp"
+          fi
+          if [ -z "$changes_md" ]; then
+            echo 'Changes (Markdown): [none]'
+          else
+            echo -e "Changes (Markdown):\n$changes_md"
+          fi
+          changes_externals=${changes_externals//$'\n'/'\0'}
+          delimiter=$(head -c 16 /dev/urandom | base64)
+          echo "run-build=$build" >> $GITHUB_OUTPUT
+          echo "run-check-licenses=$check_licenses" >> $GITHUB_OUTPUT
+          echo "run-format-check-c-cpp=$format_check_c_cpp" >> $GITHUB_OUTPUT
+          echo "run-format-check-md=$format_check_md" >> $GITHUB_OUTPUT
+          echo "changes-externals=$changes_externals" >> $GITHUB_OUTPUT
+          echo "changes-c-cpp<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$changes_c_cpp" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
+          echo "changes-md<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$changes_md" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
+  ci:
+    name: CI
+    needs:
+      - analyze-changes
+    uses: ./.github/workflows/ci.yml
+    with:
+      run-build: ${{needs.analyze-changes.outputs.run-build == 'true'}}
+      run-check-licenses: ${{needs.analyze-changes.outputs.run-check-licenses == 'true'}}
+      run-format-check-c-cpp: ${{needs.analyze-changes.outputs.run-format-check-c-cpp == 'true'}}
+      run-format-check-md: ${{needs.analyze-changes.outputs.run-format-check-md == 'true'}}
+      changes-externals: ${{needs.analyze-changes.outputs.changes-externals}}
+      changes-c-cpp: ${{needs.analyze-changes.outputs.changes-c-cpp}}
+      changes-md: ${{needs.analyze-changes.outputs.changes-md}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,3 +9,8 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    with:
+      run-build: true
+      run-check-licenses: true
+      run-format-check-c-cpp: true
+      run-format-check-md: true

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ subfolder called `build` within the root of the checked out code-base.
 
 #### Linux
 
-```sh
+```console
 cmake \
   -G[Ninja|"Unix Makefiles"] \
   -DCMAKE_C_COMPILER=[gcc|clang] \ # optional, default cc will be used
@@ -62,7 +62,7 @@ only `gcc/g++` **9**, **10** and **11** are supported along with `clang` **10**,
 
 #### Windows
 
-```sh
+```console
 cmake \
   -G[Ninja|"Visual Studio 15 2017"|"Visual Studio 16 2019"] \
   -Thost=x64 \  # Not needed for Ninja generator
@@ -85,7 +85,7 @@ required if you only have a single version of **Visual Studio** installed.
 
 #### Android
 
-```sh
+```console
 cmake \
   -G[Ninja|"Unix Makefiles"] \
   -DCMAKE_TOOLCHAIN_FILE=[WNFramework Root]/Overlays/Posix/Overlays/Android/android.toolchain.cmake \
@@ -106,7 +106,7 @@ All building is done via **CMake**. All steps below assume you are within a
 subfolder called `build` within the root of the code-base and a configuration
 has already completed successfully
 
-```sh
+```console
 cmake --build .
 ```
 
@@ -124,7 +124,7 @@ All testing is done via **CMake**. All steps below assume you are within a
 subfolder called `build` within the root of the code-base and a build has
 already completed successfully.
 
-```sh
+```console
 ctest
 ```
 

--- a/externals/librocket/Include/Rocket/Controls.h
+++ b/externals/librocket/Include/Rocket/Controls.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLS_H
 #define ROCKETCONTROLS_H
 

--- a/externals/librocket/Include/Rocket/Controls/Clipboard.h
+++ b/externals/librocket/Include/Rocket/Controls/Clipboard.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSCLIPBOARD_H
 #define ROCKETCONTROLSCLIPBOARD_H
 

--- a/externals/librocket/Include/Rocket/Controls/Controls.h
+++ b/externals/librocket/Include/Rocket/Controls/Controls.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSCONTROLS_H
 #define ROCKETCONTROLSCONTROLS_H
 

--- a/externals/librocket/Include/Rocket/Controls/DataFormatter.h
+++ b/externals/librocket/Include/Rocket/Controls/DataFormatter.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSDATAFORMATTER_H
 #define ROCKETCONTROLSDATAFORMATTER_H
 

--- a/externals/librocket/Include/Rocket/Controls/DataQuery.h
+++ b/externals/librocket/Include/Rocket/Controls/DataQuery.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSDATAQUERY_H
 #define ROCKETCONTROLSDATAQUERY_H
 

--- a/externals/librocket/Include/Rocket/Controls/DataSource.h
+++ b/externals/librocket/Include/Rocket/Controls/DataSource.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSDATASOURCE_H
 #define ROCKETCONTROLSDATASOURCE_H
 

--- a/externals/librocket/Include/Rocket/Controls/DataSourceListener.h
+++ b/externals/librocket/Include/Rocket/Controls/DataSourceListener.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSDATASOURCELISTENER_H
 #define ROCKETCONTROLSDATASOURCELISTENER_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementDataGrid.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementDataGrid.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTDATAGRID_H
 #define ROCKETCONTROLSELEMENTDATAGRID_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementDataGridCell.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementDataGridCell.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTDATAGRIDCELL_H
 #define ROCKETCONTROLSELEMENTDATAGRIDCELL_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementDataGridExpandButton.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementDataGridExpandButton.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTDATAGRIDEXPANDBUTTON_H
 #define ROCKETCONTROLSELEMENTDATAGRIDEXPANDBUTTON_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementDataGridRow.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementDataGridRow.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTDATAGRIDROW_H
 #define ROCKETCONTROLSELEMENTDATAGRIDROW_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementForm.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementForm.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTFORM_H
 #define ROCKETCONTROLSELEMENTFORM_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementFormControl.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementFormControl.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTFORMCONTROL_H
 #define ROCKETCONTROLSELEMENTFORMCONTROL_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementFormControlDataSelect.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementFormControlDataSelect.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTFORMCONTROLDATASELECT_H
 #define ROCKETCONTROLSELEMENTFORMCONTROLDATASELECT_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementFormControlInput.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementFormControlInput.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTFORMCONTROLINPUT_H
 #define ROCKETCONTROLSELEMENTFORMCONTROLINPUT_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementFormControlSelect.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementFormControlSelect.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTFORMCONTROLSELECT_H
 #define ROCKETCONTROLSELEMENTFORMCONTROLSELECT_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementFormControlTextArea.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementFormControlTextArea.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTFORMCONTROLTEXTAREA_H
 #define ROCKETCONTROLSELEMENTFORMCONTROLTEXTAREA_H
 

--- a/externals/librocket/Include/Rocket/Controls/ElementTabSet.h
+++ b/externals/librocket/Include/Rocket/Controls/ElementTabSet.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTTABSET_H
 #define ROCKETCONTROLSELEMENTTABSET_H
 

--- a/externals/librocket/Include/Rocket/Controls/SelectOption.h
+++ b/externals/librocket/Include/Rocket/Controls/SelectOption.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSSELECTOPTION_H
 #define ROCKETCONTROLSSELECTOPTION_H
 

--- a/externals/librocket/Include/Rocket/Core.h
+++ b/externals/librocket/Include/Rocket/Core.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORE_H
 #define ROCKETCORE_H
 

--- a/externals/librocket/Include/Rocket/Core/BaseXMLParser.h
+++ b/externals/librocket/Include/Rocket/Core/BaseXMLParser.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBASEXMLPARSER_H
 #define ROCKETCOREBASEXMLPARSER_H
 

--- a/externals/librocket/Include/Rocket/Core/BitmapFont/FontProvider.h
+++ b/externals/librocket/Include/Rocket/Core/BitmapFont/FontProvider.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBITMAPFONTFONTPROVIDER_H
 #define ROCKETCOREBITMAPFONTFONTPROVIDER_H
 

--- a/externals/librocket/Include/Rocket/Core/Box.h
+++ b/externals/librocket/Include/Rocket/Core/Box.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBOX_H
 #define ROCKETCOREBOX_H
 

--- a/externals/librocket/Include/Rocket/Core/Colour.h
+++ b/externals/librocket/Include/Rocket/Core/Colour.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORECOLOUR_H
 #define ROCKETCORECOLOUR_H
 

--- a/externals/librocket/Include/Rocket/Core/Context.h
+++ b/externals/librocket/Include/Rocket/Core/Context.h
@@ -1,6 +1,35 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
 
 #ifndef ROCKETCORECONTEXT_H__
 #define ROCKETCORECONTEXT_H__

--- a/externals/librocket/Include/Rocket/Core/ConvolutionFilter.h
+++ b/externals/librocket/Include/Rocket/Core/ConvolutionFilter.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORECONVOLUTIONFILTER_H
 #define ROCKETCORECONVOLUTIONFILTER_H
 

--- a/externals/librocket/Include/Rocket/Core/Core.h
+++ b/externals/librocket/Include/Rocket/Core/Core.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORECORE_H
 #define ROCKETCORECORE_H
 

--- a/externals/librocket/Include/Rocket/Core/Debug.h
+++ b/externals/librocket/Include/Rocket/Core/Debug.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDEBUG_H
 #define ROCKETCOREDEBUG_H
 

--- a/externals/librocket/Include/Rocket/Core/Decorator.h
+++ b/externals/librocket/Include/Rocket/Core/Decorator.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATOR_H
 #define ROCKETCOREDECORATOR_H
 

--- a/externals/librocket/Include/Rocket/Core/DecoratorInstancer.h
+++ b/externals/librocket/Include/Rocket/Core/DecoratorInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORINSTANCER_H
 #define ROCKETCOREDECORATORINSTANCER_H
 

--- a/externals/librocket/Include/Rocket/Core/Dictionary.h
+++ b/externals/librocket/Include/Rocket/Core/Dictionary.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDICTIONARY_H
 #define ROCKETCOREDICTIONARY_H
 

--- a/externals/librocket/Include/Rocket/Core/DocumentContext.h
+++ b/externals/librocket/Include/Rocket/Core/DocumentContext.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDOCUMENTCONTEXT_H
 #define ROCKETCOREDOCUMENTCONTEXT_H
 

--- a/externals/librocket/Include/Rocket/Core/DocumentContextInstancer.h
+++ b/externals/librocket/Include/Rocket/Core/DocumentContextInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORECONTEXTINSTANCER_H
 #define ROCKETCORECONTEXTINSTANCER_H
 

--- a/externals/librocket/Include/Rocket/Core/Element.h
+++ b/externals/librocket/Include/Rocket/Core/Element.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENT_H
 #define ROCKETCOREELEMENT_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementDocument.h
+++ b/externals/librocket/Include/Rocket/Core/ElementDocument.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTDOCUMENT_H
 #define ROCKETCOREELEMENTDOCUMENT_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementInstancer.h
+++ b/externals/librocket/Include/Rocket/Core/ElementInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTINSTANCER_H
 #define ROCKETCOREELEMENTINSTANCER_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementInstancerGeneric.h
+++ b/externals/librocket/Include/Rocket/Core/ElementInstancerGeneric.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTINSTANCERGENERIC_H
 #define ROCKETCOREELEMENTINSTANCERGENERIC_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementReference.h
+++ b/externals/librocket/Include/Rocket/Core/ElementReference.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTREFERENCE_H
 #define ROCKETCOREELEMENTREFERENCE_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementScroll.h
+++ b/externals/librocket/Include/Rocket/Core/ElementScroll.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTSCROLL_H
 #define ROCKETCOREELEMENTSCROLL_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementText.h
+++ b/externals/librocket/Include/Rocket/Core/ElementText.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTTEXT_H
 #define ROCKETCOREELEMENTTEXT_H
 

--- a/externals/librocket/Include/Rocket/Core/ElementUtilities.h
+++ b/externals/librocket/Include/Rocket/Core/ElementUtilities.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTUTILITIES_H
 #define ROCKETCOREELEMENTUTILITIES_H
 

--- a/externals/librocket/Include/Rocket/Core/Event.h
+++ b/externals/librocket/Include/Rocket/Core/Event.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENT_H
 #define ROCKETCOREEVENT_H
 

--- a/externals/librocket/Include/Rocket/Core/EventInstancer.h
+++ b/externals/librocket/Include/Rocket/Core/EventInstancer.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENTINSTANCER_H
 #define ROCKETCOREEVENTINSTANCER_H
 

--- a/externals/librocket/Include/Rocket/Core/EventListener.h
+++ b/externals/librocket/Include/Rocket/Core/EventListener.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENTLISTENER_H
 #define ROCKETCOREEVENTLISTENER_H
 

--- a/externals/librocket/Include/Rocket/Core/EventListenerInstancer.h
+++ b/externals/librocket/Include/Rocket/Core/EventListenerInstancer.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENTLISTENERINSTANCER_H
 #define ROCKETCOREEVENTLISTENERINSTANCER_H
 

--- a/externals/librocket/Include/Rocket/Core/Factory.h
+++ b/externals/librocket/Include/Rocket/Core/Factory.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFACTORY_H
 #define ROCKETCOREFACTORY_H
 

--- a/externals/librocket/Include/Rocket/Core/FileInterface.h
+++ b/externals/librocket/Include/Rocket/Core/FileInterface.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFILEINTERFACE_H
 #define ROCKETCOREFILEINTERFACE_H
 

--- a/externals/librocket/Include/Rocket/Core/Font.h
+++ b/externals/librocket/Include/Rocket/Core/Font.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONT_H
 #define ROCKETCOREFONT_H
 

--- a/externals/librocket/Include/Rocket/Core/FontDatabase.h
+++ b/externals/librocket/Include/Rocket/Core/FontDatabase.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTDATABASE_H
 #define ROCKETCOREFONTDATABASE_H
 

--- a/externals/librocket/Include/Rocket/Core/FontEffect.h
+++ b/externals/librocket/Include/Rocket/Core/FontEffect.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECT_H
 #define ROCKETCOREFONTEFFECT_H
 

--- a/externals/librocket/Include/Rocket/Core/FontEffectInstancer.h
+++ b/externals/librocket/Include/Rocket/Core/FontEffectInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECTINSTANCER_H
 #define ROCKETCOREFONTEFFECTINSTANCER_H
 

--- a/externals/librocket/Include/Rocket/Core/FontFace.h
+++ b/externals/librocket/Include/Rocket/Core/FontFace.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTFACE_H
 #define ROCKETCOREFONTFACE_H
 

--- a/externals/librocket/Include/Rocket/Core/FontFamily.h
+++ b/externals/librocket/Include/Rocket/Core/FontFamily.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTFAMILY_H
 #define ROCKETCOREFONTFAMILY_H
 

--- a/externals/librocket/Include/Rocket/Core/FontGlyph.h
+++ b/externals/librocket/Include/Rocket/Core/FontGlyph.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTGLYPH_H
 #define ROCKETCOREFONTGLYPH_H
 

--- a/externals/librocket/Include/Rocket/Core/FontProvider.h
+++ b/externals/librocket/Include/Rocket/Core/FontProvider.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTPROVIDER_H
 #define ROCKETCOREFONTPROVIDER_H
 

--- a/externals/librocket/Include/Rocket/Core/Geometry.h
+++ b/externals/librocket/Include/Rocket/Core/Geometry.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREGEOMETRY_H
 #define ROCKETCOREGEOMETRY_H
 

--- a/externals/librocket/Include/Rocket/Core/GeometryUtilities.h
+++ b/externals/librocket/Include/Rocket/Core/GeometryUtilities.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREGEOMETRYUTILITIES_H
 #define ROCKETCOREGEOMETRYUTILITIES_H
 

--- a/externals/librocket/Include/Rocket/Core/Input.h
+++ b/externals/librocket/Include/Rocket/Core/Input.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREINPUT_H
 #define ROCKETCOREINPUT_H
 

--- a/externals/librocket/Include/Rocket/Core/Log.h
+++ b/externals/librocket/Include/Rocket/Core/Log.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELOG_H
 #define ROCKETCORELOG_H
 

--- a/externals/librocket/Include/Rocket/Core/Math.h
+++ b/externals/librocket/Include/Rocket/Core/Math.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREMATH_H
 #define ROCKETCOREMATH_H
 

--- a/externals/librocket/Include/Rocket/Core/MathTypes.h
+++ b/externals/librocket/Include/Rocket/Core/MathTypes.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREMATHTYPES_H
 #define ROCKETCOREMATHTYPES_H
 

--- a/externals/librocket/Include/Rocket/Core/Platform.h
+++ b/externals/librocket/Include/Rocket/Core/Platform.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPLATFORM_H
 #define ROCKETCOREPLATFORM_H
 

--- a/externals/librocket/Include/Rocket/Core/Plugin.h
+++ b/externals/librocket/Include/Rocket/Core/Plugin.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPLUGIN_H
 #define ROCKETCOREPLUGIN_H
 

--- a/externals/librocket/Include/Rocket/Core/Property.h
+++ b/externals/librocket/Include/Rocket/Core/Property.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTY_H
 #define ROCKETCOREPROPERTY_H
 

--- a/externals/librocket/Include/Rocket/Core/PropertyDefinition.h
+++ b/externals/librocket/Include/Rocket/Core/PropertyDefinition.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYDEFINITION_H
 #define ROCKETCOREPROPERTYDEFINITION_H
 

--- a/externals/librocket/Include/Rocket/Core/PropertyDictionary.h
+++ b/externals/librocket/Include/Rocket/Core/PropertyDictionary.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYDICTIONARY_H
 #define ROCKETCOREPROPERTYDICTIONARY_H
 

--- a/externals/librocket/Include/Rocket/Core/PropertyParser.h
+++ b/externals/librocket/Include/Rocket/Core/PropertyParser.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYPARSER_H
 #define ROCKETCOREPROPERTYPARSER_H
 

--- a/externals/librocket/Include/Rocket/Core/PropertySpecification.h
+++ b/externals/librocket/Include/Rocket/Core/PropertySpecification.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYSPECIFICATION_H
 #define ROCKETCOREPROPERTYSPECIFICATION_H
 

--- a/externals/librocket/Include/Rocket/Core/ReferenceCountable.h
+++ b/externals/librocket/Include/Rocket/Core/ReferenceCountable.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREREFERENCECOUNTABLE_H
 #define ROCKETCOREREFERENCECOUNTABLE_H
 

--- a/externals/librocket/Include/Rocket/Core/RenderInterface.h
+++ b/externals/librocket/Include/Rocket/Core/RenderInterface.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORERENDERINTERFACE_H
 #define ROCKETCORERENDERINTERFACE_H
 

--- a/externals/librocket/Include/Rocket/Core/ScriptInterface.h
+++ b/externals/librocket/Include/Rocket/Core/ScriptInterface.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESCRIPTINTERFACE_H
 #define ROCKETCORESCRIPTINTERFACE_H
 

--- a/externals/librocket/Include/Rocket/Core/Stream.h
+++ b/externals/librocket/Include/Rocket/Core/Stream.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTREAM_H
 #define ROCKETCORESTREAM_H
 

--- a/externals/librocket/Include/Rocket/Core/StreamMemory.h
+++ b/externals/librocket/Include/Rocket/Core/StreamMemory.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTREAMMEMORY_H
 #define ROCKETCORESTREAMMEMORY_H
 

--- a/externals/librocket/Include/Rocket/Core/String.h
+++ b/externals/librocket/Include/Rocket/Core/String.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTRING_H
 #define ROCKETCORESTRING_H
 

--- a/externals/librocket/Include/Rocket/Core/StringBase.h
+++ b/externals/librocket/Include/Rocket/Core/StringBase.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTRINGBASE_H
 #define ROCKETCORESTRINGBASE_H
 

--- a/externals/librocket/Include/Rocket/Core/StringUtilities.h
+++ b/externals/librocket/Include/Rocket/Core/StringUtilities.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTRINGUTILITIES_H
 #define ROCKETCORESTRINGUTILITIES_H
 

--- a/externals/librocket/Include/Rocket/Core/StyleSheet.h
+++ b/externals/librocket/Include/Rocket/Core/StyleSheet.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEET_H
 #define ROCKETCORESTYLESHEET_H
 

--- a/externals/librocket/Include/Rocket/Core/StyleSheetKeywords.h
+++ b/externals/librocket/Include/Rocket/Core/StyleSheetKeywords.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETKEYWORDS_H
 #define ROCKETCORESTYLESHEETKEYWORDS_H
 

--- a/externals/librocket/Include/Rocket/Core/StyleSheetSpecification.h
+++ b/externals/librocket/Include/Rocket/Core/StyleSheetSpecification.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETSPECIFICATION_H
 #define ROCKETCORESTYLESHEETSPECIFICATION_H
 

--- a/externals/librocket/Include/Rocket/Core/SystemInterface.h
+++ b/externals/librocket/Include/Rocket/Core/SystemInterface.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESYSTEMINTERFACE_H
 #define ROCKETCORESYSTEMINTERFACE_H
 

--- a/externals/librocket/Include/Rocket/Core/TTFFont/FontProvider.h
+++ b/externals/librocket/Include/Rocket/Core/TTFFont/FontProvider.h
@@ -1,6 +1,36 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETTFFONTFONTPROVIDER_H
 #define ROCKETCORETTFFONTFONTPROVIDER_H
 

--- a/externals/librocket/Include/Rocket/Core/Texture.h
+++ b/externals/librocket/Include/Rocket/Core/Texture.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETEXTURE_H
 #define ROCKETCORETEXTURE_H
 

--- a/externals/librocket/Include/Rocket/Core/TypeConverter.h
+++ b/externals/librocket/Include/Rocket/Core/TypeConverter.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETYPECONVERTER_H
 #define ROCKETCORETYPECONVERTER_H
 

--- a/externals/librocket/Include/Rocket/Core/Types.h
+++ b/externals/librocket/Include/Rocket/Core/Types.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETYPES_H
 #define ROCKETCORETYPES_H
 

--- a/externals/librocket/Include/Rocket/Core/URL.h
+++ b/externals/librocket/Include/Rocket/Core/URL.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREURL_H
 #define ROCKETCOREURL_H
 

--- a/externals/librocket/Include/Rocket/Core/Variant.h
+++ b/externals/librocket/Include/Rocket/Core/Variant.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETVARIANT_H
 #define ROCKETVARIANT_H
 

--- a/externals/librocket/Include/Rocket/Core/Vector2.h
+++ b/externals/librocket/Include/Rocket/Core/Vector2.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREVECTOR2_H
 #define ROCKETCOREVECTOR2_H
 

--- a/externals/librocket/Include/Rocket/Core/Vertex.h
+++ b/externals/librocket/Include/Rocket/Core/Vertex.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREVERTEX_H
 #define ROCKETCOREVERTEX_H
 

--- a/externals/librocket/Include/Rocket/Core/WString.h
+++ b/externals/librocket/Include/Rocket/Core/WString.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREWSTRING_H
 #define ROCKETCOREWSTRING_H
 

--- a/externals/librocket/Include/Rocket/Core/XMLNodeHandler.h
+++ b/externals/librocket/Include/Rocket/Core/XMLNodeHandler.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLNODEHANDLER_H
 #define ROCKETCOREXMLNODEHANDLER_H
 

--- a/externals/librocket/Include/Rocket/Core/XMLParser.h
+++ b/externals/librocket/Include/Rocket/Core/XMLParser.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLPARSER_H
 #define ROCKETCOREXMLPARSER_H
 

--- a/externals/librocket/Include/Rocket/Debugger.h
+++ b/externals/librocket/Include/Rocket/Debugger.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGER_H
 #define ROCKETDEBUGGER_H
 

--- a/externals/librocket/Include/Rocket/Debugger/Debugger.h
+++ b/externals/librocket/Include/Rocket/Debugger/Debugger.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERDEBUGGER_H
 #define ROCKETDEBUGGERDEBUGGER_H
 

--- a/externals/librocket/Source/Controls/Clipboard.cpp
+++ b/externals/librocket/Source/Controls/Clipboard.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/Clipboard.h"
 #include "../../Include/Rocket/Core/Context.h"
 #include "../../Include/Rocket/Core/Types.h"

--- a/externals/librocket/Source/Controls/Controls.cpp
+++ b/externals/librocket/Source/Controls/Controls.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/Controls.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"
 #include "../../Include/Rocket/Core/Context.h"

--- a/externals/librocket/Source/Controls/DataFormatter.cpp
+++ b/externals/librocket/Source/Controls/DataFormatter.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/DataFormatter.h"
 
 namespace Rocket {

--- a/externals/librocket/Source/Controls/DataQuery.cpp
+++ b/externals/librocket/Source/Controls/DataQuery.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/DataQuery.h"
 #include <algorithm>
 #include "../../Include/Rocket/Controls/DataSource.h"

--- a/externals/librocket/Source/Controls/DataSource.cpp
+++ b/externals/librocket/Source/Controls/DataSource.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/DataSource.h"
 #include <algorithm>
 #include "../../Include/Rocket/Controls/DataSourceListener.h"

--- a/externals/librocket/Source/Controls/DataSourceListener.cpp
+++ b/externals/librocket/Source/Controls/DataSourceListener.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/DataSourceListener.h"
 #include "../../Include/Rocket/Controls/DataSource.h"
 #include "../../Include/Rocket/Core/Log.h"

--- a/externals/librocket/Source/Controls/ElementDataGrid.cpp
+++ b/externals/librocket/Source/Controls/ElementDataGrid.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementDataGrid.h"
 #include "../../Include/Rocket/Controls/DataFormatter.h"
 #include "../../Include/Rocket/Controls/DataSource.h"

--- a/externals/librocket/Source/Controls/ElementDataGridCell.cpp
+++ b/externals/librocket/Source/Controls/ElementDataGridCell.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementDataGridCell.h"
 #include "../../Include/Rocket/Controls/ElementDataGrid.h"
 #include "../../Include/Rocket/Core/Event.h"

--- a/externals/librocket/Source/Controls/ElementDataGridExpandButton.cpp
+++ b/externals/librocket/Source/Controls/ElementDataGridExpandButton.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementDataGridExpandButton.h"
 #include "../../Include/Rocket/Controls/ElementDataGridRow.h"
 

--- a/externals/librocket/Source/Controls/ElementDataGridRow.cpp
+++ b/externals/librocket/Source/Controls/ElementDataGridRow.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementDataGridRow.h"
 #include "../../Include/Rocket/Controls/DataFormatter.h"
 #include "../../Include/Rocket/Controls/DataSource.h"

--- a/externals/librocket/Source/Controls/ElementForm.cpp
+++ b/externals/librocket/Source/Controls/ElementForm.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementForm.h"
 #include "../../Include/Rocket/Controls/ElementFormControl.h"
 #include "../../Include/Rocket/Core/Dictionary.h"

--- a/externals/librocket/Source/Controls/ElementFormControl.cpp
+++ b/externals/librocket/Source/Controls/ElementFormControl.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementFormControl.h"
 
 namespace Rocket {

--- a/externals/librocket/Source/Controls/ElementFormControlDataSelect.cpp
+++ b/externals/librocket/Source/Controls/ElementFormControlDataSelect.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementFormControlDataSelect.h"
 #include "../../Include/Rocket/Controls/DataFormatter.h"
 #include "../../Include/Rocket/Controls/DataQuery.h"

--- a/externals/librocket/Source/Controls/ElementFormControlInput.cpp
+++ b/externals/librocket/Source/Controls/ElementFormControlInput.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"
 #include "../../Include/Rocket/Core/Event.h"
 #include "InputTypeButton.h"

--- a/externals/librocket/Source/Controls/ElementFormControlSelect.cpp
+++ b/externals/librocket/Source/Controls/ElementFormControlSelect.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementFormControlSelect.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Controls/ElementFormControlTextArea.cpp
+++ b/externals/librocket/Source/Controls/ElementFormControlTextArea.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementFormControlTextArea.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Controls/ElementTabSet.cpp
+++ b/externals/librocket/Source/Controls/ElementTabSet.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/ElementTabSet.h"
 #include "../../Include/Rocket/Core/Factory.h"
 #include "../../Include/Rocket/Core/Math.h"

--- a/externals/librocket/Source/Controls/ElementTextSelection.cpp
+++ b/externals/librocket/Source/Controls/ElementTextSelection.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementTextSelection.h"
 #include "WidgetTextInput.h"
 

--- a/externals/librocket/Source/Controls/ElementTextSelection.h
+++ b/externals/librocket/Source/Controls/ElementTextSelection.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSELEMENTTEXTSELECTION_H
 #define ROCKETCONTROLSELEMENTTEXTSELECTION_H
 

--- a/externals/librocket/Source/Controls/InputType.cpp
+++ b/externals/librocket/Source/Controls/InputType.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "InputType.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"
 

--- a/externals/librocket/Source/Controls/InputType.h
+++ b/externals/librocket/Source/Controls/InputType.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPE_H
 #define ROCKETCONTROLSINPUTTYPE_H
 

--- a/externals/librocket/Source/Controls/InputTypeButton.cpp
+++ b/externals/librocket/Source/Controls/InputTypeButton.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "InputTypeButton.h"
 #include "../../Include/Rocket/Controls/ElementForm.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"

--- a/externals/librocket/Source/Controls/InputTypeButton.h
+++ b/externals/librocket/Source/Controls/InputTypeButton.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPEBUTTON_H
 #define ROCKETCONTROLSINPUTTYPEBUTTON_H
 

--- a/externals/librocket/Source/Controls/InputTypeCheckbox.cpp
+++ b/externals/librocket/Source/Controls/InputTypeCheckbox.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "InputTypeCheckbox.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"
 

--- a/externals/librocket/Source/Controls/InputTypeCheckbox.h
+++ b/externals/librocket/Source/Controls/InputTypeCheckbox.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPECHECKBOX_H
 #define ROCKETCONTROLSINPUTTYPECHECKBOX_H
 

--- a/externals/librocket/Source/Controls/InputTypeRadio.cpp
+++ b/externals/librocket/Source/Controls/InputTypeRadio.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "InputTypeRadio.h"
 #include "../../Include/Rocket/Controls/ElementForm.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"

--- a/externals/librocket/Source/Controls/InputTypeRadio.h
+++ b/externals/librocket/Source/Controls/InputTypeRadio.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPERADIO_H
 #define ROCKETCONTROLSINPUTTYPERADIO_H
 

--- a/externals/librocket/Source/Controls/InputTypeRange.cpp
+++ b/externals/librocket/Source/Controls/InputTypeRange.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "InputTypeRange.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"
 #include "WidgetSliderInput.h"

--- a/externals/librocket/Source/Controls/InputTypeRange.h
+++ b/externals/librocket/Source/Controls/InputTypeRange.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPERANGE_H
 #define ROCKETCONTROLSINPUTTYPERANGE_H
 

--- a/externals/librocket/Source/Controls/InputTypeSubmit.cpp
+++ b/externals/librocket/Source/Controls/InputTypeSubmit.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "InputTypeSubmit.h"
 #include "../../Include/Rocket/Controls/ElementForm.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"

--- a/externals/librocket/Source/Controls/InputTypeSubmit.h
+++ b/externals/librocket/Source/Controls/InputTypeSubmit.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPESUBMIT_H
 #define ROCKETCONTROLSINPUTTYPESUBMIT_H
 

--- a/externals/librocket/Source/Controls/InputTypeText.cpp
+++ b/externals/librocket/Source/Controls/InputTypeText.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "InputTypeText.h"
 #include "../../Include/Rocket/Controls/ElementFormControlInput.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Controls/InputTypeText.h
+++ b/externals/librocket/Source/Controls/InputTypeText.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSINPUTTYPETEXT_H
 #define ROCKETCONTROLSINPUTTYPETEXT_H
 

--- a/externals/librocket/Source/Controls/SelectOption.cpp
+++ b/externals/librocket/Source/Controls/SelectOption.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Controls/SelectOption.h"
 
 namespace Rocket {

--- a/externals/librocket/Source/Controls/WidgetDropDown.cpp
+++ b/externals/librocket/Source/Controls/WidgetDropDown.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetDropDown.h"
 #include "../../Include/Rocket/Controls/ElementFormControl.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Controls/WidgetDropDown.h
+++ b/externals/librocket/Source/Controls/WidgetDropDown.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETDROPDOWN_H
 #define ROCKETCONTROLSWIDGETDROPDOWN_H
 

--- a/externals/librocket/Source/Controls/WidgetSlider.cpp
+++ b/externals/librocket/Source/Controls/WidgetSlider.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetSlider.h"
 #include "../../Include/Rocket/Controls/ElementFormControl.h"
 #include "../../Include/Rocket/Core.h"

--- a/externals/librocket/Source/Controls/WidgetSlider.h
+++ b/externals/librocket/Source/Controls/WidgetSlider.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETSLIDER_H
 #define ROCKETCONTROLSWIDGETSLIDER_H
 

--- a/externals/librocket/Source/Controls/WidgetSliderInput.cpp
+++ b/externals/librocket/Source/Controls/WidgetSliderInput.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetSliderInput.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Math.h"

--- a/externals/librocket/Source/Controls/WidgetSliderInput.h
+++ b/externals/librocket/Source/Controls/WidgetSliderInput.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETSLIDERINPUT_H
 #define ROCKETCONTROLSWIDGETSLIDERINPUT_H
 

--- a/externals/librocket/Source/Controls/WidgetTextInput.cpp
+++ b/externals/librocket/Source/Controls/WidgetTextInput.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetTextInput.h"
 #include "../../Include/Rocket/Controls/Clipboard.h"
 #include "../../Include/Rocket/Controls/ElementFormControl.h"

--- a/externals/librocket/Source/Controls/WidgetTextInput.h
+++ b/externals/librocket/Source/Controls/WidgetTextInput.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUT_H
 #define ROCKETCONTROLSWIDGETTEXTINPUT_H
 

--- a/externals/librocket/Source/Controls/WidgetTextInputMultiLine.cpp
+++ b/externals/librocket/Source/Controls/WidgetTextInputMultiLine.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetTextInputMultiLine.h"
 #include "../../Include/Rocket/Core/Dictionary.h"
 #include "../../Include/Rocket/Core/ElementText.h"

--- a/externals/librocket/Source/Controls/WidgetTextInputMultiLine.h
+++ b/externals/librocket/Source/Controls/WidgetTextInputMultiLine.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUTMULTILINE_H
 #define ROCKETCONTROLSWIDGETTEXTINPUTMULTILINE_H
 

--- a/externals/librocket/Source/Controls/WidgetTextInputSingleLine.cpp
+++ b/externals/librocket/Source/Controls/WidgetTextInputSingleLine.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetTextInputSingleLine.h"
 #include "../../Include/Rocket/Core/Dictionary.h"
 #include "../../Include/Rocket/Core/ElementText.h"

--- a/externals/librocket/Source/Controls/WidgetTextInputSingleLine.h
+++ b/externals/librocket/Source/Controls/WidgetTextInputSingleLine.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINE_H
 #define ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINE_H
 

--- a/externals/librocket/Source/Controls/WidgetTextInputSingleLinePassword.cpp
+++ b/externals/librocket/Source/Controls/WidgetTextInputSingleLinePassword.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetTextInputSingleLinePassword.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 

--- a/externals/librocket/Source/Controls/WidgetTextInputSingleLinePassword.h
+++ b/externals/librocket/Source/Controls/WidgetTextInputSingleLinePassword.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINEPASSWORD_H
 #define ROCKETCONTROLSWIDGETTEXTINPUTSINGLELINEPASSWORD_H
 

--- a/externals/librocket/Source/Controls/XMLNodeHandlerDataGrid.cpp
+++ b/externals/librocket/Source/Controls/XMLNodeHandlerDataGrid.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerDataGrid.h"
 #include "../../Include/Rocket/Controls/ElementDataGrid.h"
 #include "../../Include/Rocket/Core/Factory.h"

--- a/externals/librocket/Source/Controls/XMLNodeHandlerDataGrid.h
+++ b/externals/librocket/Source/Controls/XMLNodeHandlerDataGrid.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSXMLNODEHANDLERDATAGRID_H
 #define ROCKETCONTROLSXMLNODEHANDLERDATAGRID_H
 

--- a/externals/librocket/Source/Controls/XMLNodeHandlerTabSet.cpp
+++ b/externals/librocket/Source/Controls/XMLNodeHandlerTabSet.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerTabSet.h"
 #include "../../Include/Rocket/Controls/ElementTabSet.h"
 #include "../../Include/Rocket/Core/Factory.h"

--- a/externals/librocket/Source/Controls/XMLNodeHandlerTabSet.h
+++ b/externals/librocket/Source/Controls/XMLNodeHandlerTabSet.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSXMLNODEHANDLERTABSET_H
 #define ROCKETCONTROLSXMLNODEHANDLERTABSET_H
 

--- a/externals/librocket/Source/Controls/XMLNodeHandlerTextArea.cpp
+++ b/externals/librocket/Source/Controls/XMLNodeHandlerTextArea.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerTextArea.h"
 #include "../../Include/Rocket/Controls/ElementFormControlTextArea.h"
 #include "../../Include/Rocket/Core.h"

--- a/externals/librocket/Source/Controls/XMLNodeHandlerTextArea.h
+++ b/externals/librocket/Source/Controls/XMLNodeHandlerTextArea.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCONTROLSXMLNODEHANDLERTEXTAREA_H
 #define ROCKETCONTROLSXMLNODEHANDLERTEXTAREA_H
 

--- a/externals/librocket/Source/Core/BaseXMLParser.cpp
+++ b/externals/librocket/Source/Core/BaseXMLParser.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/BaseXMLParser.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/BitmapFont/BitmapFontDefinitions.h
+++ b/externals/librocket/Source/Core/BitmapFont/BitmapFontDefinitions.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef BITMAPFONTDEFINITIONS_H
 #define BITMAPFONTDEFINITIONS_H
 

--- a/externals/librocket/Source/Core/BitmapFont/FontFace.cpp
+++ b/externals/librocket/Source/Core/BitmapFont/FontFace.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontFace.h"
 #include <Rocket/Core/Log.h>
 #include "../precompiled.h"

--- a/externals/librocket/Source/Core/BitmapFont/FontFace.h
+++ b/externals/librocket/Source/Core/BitmapFont/FontFace.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBITMAPFONTFACE_H
 #define ROCKETCOREBITMAPFONTFACE_H
 

--- a/externals/librocket/Source/Core/BitmapFont/FontFaceHandle.cpp
+++ b/externals/librocket/Source/Core/BitmapFont/FontFaceHandle.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontFaceHandle.h"
 #include <algorithm>
 #include <cmath>

--- a/externals/librocket/Source/Core/BitmapFont/FontFaceHandle.h
+++ b/externals/librocket/Source/Core/BitmapFont/FontFaceHandle.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBITMAPFONTFONTFACEHANDLE_H
 #define ROCKETCOREBITMAPFONTFONTFACEHANDLE_H
 

--- a/externals/librocket/Source/Core/BitmapFont/FontFaceLayer.cpp
+++ b/externals/librocket/Source/Core/BitmapFont/FontFaceLayer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontFaceLayer.h"
 #include "../precompiled.h"
 #include "FontFaceHandle.h"

--- a/externals/librocket/Source/Core/BitmapFont/FontFaceLayer.h
+++ b/externals/librocket/Source/Core/BitmapFont/FontFaceLayer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBITMAPFONTFACELAYER_H
 #define ROCKETCOREBITMAPFONTFACELAYER_H
 

--- a/externals/librocket/Source/Core/BitmapFont/FontFamily.cpp
+++ b/externals/librocket/Source/Core/BitmapFont/FontFamily.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontFamily.h"
 #include "../precompiled.h"
 #include "FontFace.h"

--- a/externals/librocket/Source/Core/BitmapFont/FontFamily.h
+++ b/externals/librocket/Source/Core/BitmapFont/FontFamily.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREBITMAPFONTFAMILY_H
 #define ROCKETCOREBITMAPFONTFAMILY_H
 

--- a/externals/librocket/Source/Core/BitmapFont/FontParser.cpp
+++ b/externals/librocket/Source/Core/BitmapFont/FontParser.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontParser.h"
 #include "../precompiled.h"
 

--- a/externals/librocket/Source/Core/BitmapFont/FontParser.h
+++ b/externals/librocket/Source/Core/BitmapFont/FontParser.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef BITMAPFONTPARSER_H
 #define BITMAPFONTPARSER_H
 

--- a/externals/librocket/Source/Core/BitmapFont/FontProvider.cpp
+++ b/externals/librocket/Source/Core/BitmapFont/FontProvider.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include <Rocket/Core.h>
 #include <Rocket/Core/BitmapFont/FontProvider.h>
 #include <Rocket/Core/FontDatabase.h>

--- a/externals/librocket/Source/Core/Box.cpp
+++ b/externals/librocket/Source/Core/Box.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Box.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/Clock.cpp
+++ b/externals/librocket/Source/Core/Clock.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "Clock.h"
 #include "../../Include/Rocket/Core.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/Clock.h
+++ b/externals/librocket/Source/Core/Clock.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORECLOCK_H
 #define ROCKETCORECLOCK_H
 

--- a/externals/librocket/Source/Core/ConvolutionFilter.cpp
+++ b/externals/librocket/Source/Core/ConvolutionFilter.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ConvolutionFilter.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/Core.cpp
+++ b/externals/librocket/Source/Core/Core.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core/Context.h"

--- a/externals/librocket/Source/Core/DebugFont.h
+++ b/externals/librocket/Source/Core/DebugFont.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDEBUGFONT_H
 #define ROCKETCOREDEBUGFONT_H
 

--- a/externals/librocket/Source/Core/Decorator.cpp
+++ b/externals/librocket/Source/Core/Decorator.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Decorator.h"
 #include "../../Include/Rocket/Core/DecoratorInstancer.h"
 #include "../../Include/Rocket/Core/PropertyDefinition.h"

--- a/externals/librocket/Source/Core/DecoratorInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorInstancer.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/DecoratorInstancer.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/DecoratorNone.cpp
+++ b/externals/librocket/Source/Core/DecoratorNone.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorNone.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/DecoratorNone.h
+++ b/externals/librocket/Source/Core/DecoratorNone.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORNONE_H
 #define ROCKETCOREDECORATORNONE_H
 

--- a/externals/librocket/Source/Core/DecoratorNoneInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorNoneInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorNoneInstancer.h"
 #include "DecoratorNone.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorNoneInstancer.h
+++ b/externals/librocket/Source/Core/DecoratorNoneInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORNONEINSTANCER_H
 #define ROCKETCOREDECORATORNONEINSTANCER_H
 

--- a/externals/librocket/Source/Core/DecoratorTiled.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiled.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiled.h"
 #include "../../Include/Rocket/Core.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorTiled.h
+++ b/externals/librocket/Source/Core/DecoratorTiled.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILED_H
 #define ROCKETCOREDECORATORTILED_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledBox.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledBox.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledBox.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Geometry.h"

--- a/externals/librocket/Source/Core/DecoratorTiledBox.h
+++ b/externals/librocket/Source/Core/DecoratorTiledBox.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDBOX_H
 #define ROCKETCOREDECORATORTILEDBOX_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledBoxInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledBoxInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledBoxInstancer.h"
 #include "DecoratorTiledBox.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorTiledBoxInstancer.h
+++ b/externals/librocket/Source/Core/DecoratorTiledBoxInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDBOXINSTANCER_H
 #define ROCKETCOREDECORATORTILEDBOXINSTANCER_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledHorizontal.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledHorizontal.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledHorizontal.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Geometry.h"

--- a/externals/librocket/Source/Core/DecoratorTiledHorizontal.h
+++ b/externals/librocket/Source/Core/DecoratorTiledHorizontal.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDHORIZONTAL_H
 #define ROCKETCOREDECORATORTILEDHORIZONTAL_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledHorizontalInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledHorizontalInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledHorizontalInstancer.h"
 #include "DecoratorTiledHorizontal.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorTiledHorizontalInstancer.h
+++ b/externals/librocket/Source/Core/DecoratorTiledHorizontalInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDHORIZONTALINSTANCER_H
 #define ROCKETCOREDECORATORTILEDHORIZONTALINSTANCER_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledImage.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledImage.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledImage.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Geometry.h"

--- a/externals/librocket/Source/Core/DecoratorTiledImage.h
+++ b/externals/librocket/Source/Core/DecoratorTiledImage.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDIMAGE_H
 #define ROCKETCOREDECORATORTILEDIMAGE_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledImageInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledImageInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledImageInstancer.h"
 #include "DecoratorTiledImage.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorTiledImageInstancer.h
+++ b/externals/librocket/Source/Core/DecoratorTiledImageInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDIMAGEINSTANCER_H
 #define ROCKETCOREDECORATORTILEDIMAGEINSTANCER_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledInstancer.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledInstancer.h"
 #include "../../Include/Rocket/Core/PropertyDefinition.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorTiledInstancer.h
+++ b/externals/librocket/Source/Core/DecoratorTiledInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDINSTANCER_H
 #define ROCKETCOREDECORATORTILEDINSTANCER_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledVertical.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledVertical.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledVertical.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Geometry.h"

--- a/externals/librocket/Source/Core/DecoratorTiledVertical.h
+++ b/externals/librocket/Source/Core/DecoratorTiledVertical.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDVERTICAL_H
 #define ROCKETCOREDECORATORTILEDVERTICAL_H
 

--- a/externals/librocket/Source/Core/DecoratorTiledVerticalInstancer.cpp
+++ b/externals/librocket/Source/Core/DecoratorTiledVerticalInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DecoratorTiledVerticalInstancer.h"
 #include "DecoratorTiledVertical.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DecoratorTiledVerticalInstancer.h
+++ b/externals/librocket/Source/Core/DecoratorTiledVerticalInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDECORATORTILEDVERTICALINSTANCER_H
 #define ROCKETCOREDECORATORTILEDVERTICALINSTANCER_H
 

--- a/externals/librocket/Source/Core/Dictionary.cpp
+++ b/externals/librocket/Source/Core/Dictionary.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Dictionary.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/DocumentContext.cpp
+++ b/externals/librocket/Source/Core/DocumentContext.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/DocumentContext.h"
 #include <algorithm>
 #include <iterator>

--- a/externals/librocket/Source/Core/DocumentContextInstancer.cpp
+++ b/externals/librocket/Source/Core/DocumentContextInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/DocumentContextInstancer.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/DocumentContextInstancerDefault.cpp
+++ b/externals/librocket/Source/Core/DocumentContextInstancerDefault.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DocumentContextInstancerDefault.h"
 #include "../../Include/Rocket/Core/DocumentContext.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/DocumentContextInstancerDefault.h
+++ b/externals/librocket/Source/Core/DocumentContextInstancerDefault.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDefaultContextInstancerDefault_H
 #define ROCKETCOREDefaultContextInstancerDefault_H
 

--- a/externals/librocket/Source/Core/DocumentHeader.cpp
+++ b/externals/librocket/Source/Core/DocumentHeader.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "DocumentHeader.h"
 #include "../../Include/Rocket/Core.h"
 #include "XMLParseTools.h"

--- a/externals/librocket/Source/Core/DocumentHeader.h
+++ b/externals/librocket/Source/Core/DocumentHeader.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREDOCUMENTHEADER_H
 #define ROCKETCOREDOCUMENTHEADER_H
 

--- a/externals/librocket/Source/Core/Element.cpp
+++ b/externals/librocket/Source/Core/Element.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Element.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core/Core.h"

--- a/externals/librocket/Source/Core/ElementBackground.cpp
+++ b/externals/librocket/Source/Core/ElementBackground.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementBackground.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/GeometryUtilities.h"

--- a/externals/librocket/Source/Core/ElementBackground.h
+++ b/externals/librocket/Source/Core/ElementBackground.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTBACKGROUND_H
 #define ROCKETCOREELEMENTBACKGROUND_H
 

--- a/externals/librocket/Source/Core/ElementBorder.cpp
+++ b/externals/librocket/Source/Core/ElementBorder.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementBorder.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Property.h"

--- a/externals/librocket/Source/Core/ElementBorder.h
+++ b/externals/librocket/Source/Core/ElementBorder.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTBORDER_H
 #define ROCKETCOREELEMENTBORDER_H
 

--- a/externals/librocket/Source/Core/ElementDecoration.cpp
+++ b/externals/librocket/Source/Core/ElementDecoration.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementDecoration.h"
 #include "../../Include/Rocket/Core/Decorator.h"
 #include "../../Include/Rocket/Core/Element.h"

--- a/externals/librocket/Source/Core/ElementDecoration.h
+++ b/externals/librocket/Source/Core/ElementDecoration.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTDECORATION_H
 #define ROCKETCOREELEMENTDECORATION_H
 

--- a/externals/librocket/Source/Core/ElementDefinition.cpp
+++ b/externals/librocket/Source/Core/ElementDefinition.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementDefinition.h"
 
 #ifdef __APPLE__

--- a/externals/librocket/Source/Core/ElementDefinition.h
+++ b/externals/librocket/Source/Core/ElementDefinition.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTDEFINITION_H
 #define ROCKETCOREELEMENTDEFINITION_H
 

--- a/externals/librocket/Source/Core/ElementDocument.cpp
+++ b/externals/librocket/Source/Core/ElementDocument.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ElementDocument.h"
 #include "../../Include/Rocket/Core.h"
 #include "../../Include/Rocket/Core/StreamMemory.h"

--- a/externals/librocket/Source/Core/ElementHandle.cpp
+++ b/externals/librocket/Source/Core/ElementHandle.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementHandle.h"
 #include "../../Include/Rocket/Core/ElementDocument.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Core/ElementHandle.h
+++ b/externals/librocket/Source/Core/ElementHandle.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTHANDLE_H
 #define ROCKETCOREELEMENTHANDLE_H
 

--- a/externals/librocket/Source/Core/ElementImage.cpp
+++ b/externals/librocket/Source/Core/ElementImage.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementImage.h"
 #include "../../Include/Rocket/Core.h"
 #include "TextureDatabase.h"

--- a/externals/librocket/Source/Core/ElementImage.h
+++ b/externals/librocket/Source/Core/ElementImage.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTIMAGE_H
 #define ROCKETCOREELEMENTIMAGE_H
 

--- a/externals/librocket/Source/Core/ElementInstancer.cpp
+++ b/externals/librocket/Source/Core/ElementInstancer.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ElementInstancer.h"
 #include "XMLParseTools.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/ElementReference.cpp
+++ b/externals/librocket/Source/Core/ElementReference.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ElementReference.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/ElementScroll.cpp
+++ b/externals/librocket/Source/Core/ElementScroll.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ElementScroll.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Core/ElementStyle.cpp
+++ b/externals/librocket/Source/Core/ElementStyle.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementStyle.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core/Context.h"

--- a/externals/librocket/Source/Core/ElementStyle.h
+++ b/externals/librocket/Source/Core/ElementStyle.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTSTYLE_H
 #define ROCKETCOREELEMENTSTYLE_H
 

--- a/externals/librocket/Source/Core/ElementStyleCache.cpp
+++ b/externals/librocket/Source/Core/ElementStyleCache.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementStyle.h"
 #include "ElementStyleCache.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/ElementStyleCache.h
+++ b/externals/librocket/Source/Core/ElementStyleCache.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTSTYLECACHE_H
 #define ROCKETCOREELEMENTSTYLECACHE_H
 

--- a/externals/librocket/Source/Core/ElementText.cpp
+++ b/externals/librocket/Source/Core/ElementText.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/ElementTextDefault.cpp
+++ b/externals/librocket/Source/Core/ElementTextDefault.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementTextDefault.h"
 #include "../../Include/Rocket/Core/ElementDocument.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Core/ElementTextDefault.h
+++ b/externals/librocket/Source/Core/ElementTextDefault.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREELEMENTTEXTDEFAULT_H
 #define ROCKETCOREELEMENTTEXTDEFAULT_H
 

--- a/externals/librocket/Source/Core/ElementUtilities.cpp
+++ b/externals/librocket/Source/Core/ElementUtilities.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ElementUtilities.h"
 #include <queue>
 #include "../../Include/Rocket/Core.h"

--- a/externals/librocket/Source/Core/Event.cpp
+++ b/externals/librocket/Source/Core/Event.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Event.h"
 #include "../../Include/Rocket/Core/EventInstancer.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/EventDispatcher.cpp
+++ b/externals/librocket/Source/Core/EventDispatcher.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "EventDispatcher.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Event.h"

--- a/externals/librocket/Source/Core/EventDispatcher.h
+++ b/externals/librocket/Source/Core/EventDispatcher.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENTDISPATCHER_H
 #define ROCKETCOREEVENTDISPATCHER_H
 

--- a/externals/librocket/Source/Core/EventInstancer.cpp
+++ b/externals/librocket/Source/Core/EventInstancer.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/EventInstancer.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/EventInstancerDefault.cpp
+++ b/externals/librocket/Source/Core/EventInstancerDefault.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "EventInstancerDefault.h"
 #include "../../Include/Rocket/Core/Event.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/EventInstancerDefault.h
+++ b/externals/librocket/Source/Core/EventInstancerDefault.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENTINSTANCERDEFAULT_H
 #define ROCKETCOREEVENTINSTANCERDEFAULT_H
 

--- a/externals/librocket/Source/Core/EventIterators.h
+++ b/externals/librocket/Source/Core/EventIterators.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREEVENTITERATORS_H
 #define ROCKETCOREEVENTITERATORS_H
 

--- a/externals/librocket/Source/Core/EventListenerInstancer.cpp
+++ b/externals/librocket/Source/Core/EventListenerInstancer.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/EventListenerInstancer.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/Factory.cpp
+++ b/externals/librocket/Source/Core/Factory.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core.h"
 #include "../../Include/Rocket/Core/Context.h"
 #include "../../Include/Rocket/Core/StreamMemory.h"

--- a/externals/librocket/Source/Core/FileInterface.cpp
+++ b/externals/librocket/Source/Core/FileInterface.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/FileInterface.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/FontDatabase.cpp
+++ b/externals/librocket/Source/Core/FontDatabase.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include <Rocket/Core.h>
 #include <Rocket/Core/BitmapFont/FontProvider.h>
 #include <Rocket/Core/FontDatabase.h>

--- a/externals/librocket/Source/Core/FontEffect.cpp
+++ b/externals/librocket/Source/Core/FontEffect.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/FontEffect.h"
 #include "../../Include/Rocket/Core/FontDatabase.h"
 #include "../../Include/Rocket/Core/FontEffectInstancer.h"

--- a/externals/librocket/Source/Core/FontEffectInstancer.cpp
+++ b/externals/librocket/Source/Core/FontEffectInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/FontEffectInstancer.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/FontEffectNone.cpp
+++ b/externals/librocket/Source/Core/FontEffectNone.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontEffectNone.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/FontEffectNone.h
+++ b/externals/librocket/Source/Core/FontEffectNone.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECTNONE_H
 #define ROCKETCOREFONTEFFECTNONE_H
 

--- a/externals/librocket/Source/Core/FontEffectNoneInstancer.cpp
+++ b/externals/librocket/Source/Core/FontEffectNoneInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontEffectNoneInstancer.h"
 #include "FontEffectNone.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/FontEffectNoneInstancer.h
+++ b/externals/librocket/Source/Core/FontEffectNoneInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECTNONEINSTANCER_H
 #define ROCKETCOREFONTEFFECTNONEINSTANCER_H
 

--- a/externals/librocket/Source/Core/FontEffectOutline.cpp
+++ b/externals/librocket/Source/Core/FontEffectOutline.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontEffectOutline.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/FontEffectOutline.h
+++ b/externals/librocket/Source/Core/FontEffectOutline.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECTOUTLINE_H
 #define ROCKETCOREFONTEFFECTOUTLINE_H
 

--- a/externals/librocket/Source/Core/FontEffectOutlineInstancer.cpp
+++ b/externals/librocket/Source/Core/FontEffectOutlineInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontEffectOutlineInstancer.h"
 #include "FontEffectOutline.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/FontEffectOutlineInstancer.h
+++ b/externals/librocket/Source/Core/FontEffectOutlineInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECTOUTLINEINSTANCER_H
 #define ROCKETCOREFONTEFFECTOUTLINEINSTANCER_H
 

--- a/externals/librocket/Source/Core/FontEffectShadow.cpp
+++ b/externals/librocket/Source/Core/FontEffectShadow.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontEffectShadow.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/FontEffectShadow.h
+++ b/externals/librocket/Source/Core/FontEffectShadow.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTEFFECTSHADOW_H
 #define ROCKETCOREFONTEFFECTSHADOW_H
 

--- a/externals/librocket/Source/Core/FontEffectShadowInstancer.cpp
+++ b/externals/librocket/Source/Core/FontEffectShadowInstancer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontEffectShadowInstancer.h"
 #include "FontEffectShadow.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/FontEffectShadowInstancer.h
+++ b/externals/librocket/Source/Core/FontEffectShadowInstancer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFontEffectShadowInstancer_H
 #define ROCKETCOREFontEffectShadowInstancer_H
 

--- a/externals/librocket/Source/Core/FontFace.cpp
+++ b/externals/librocket/Source/Core/FontFace.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/FontFace.h"
 #include "../../Include/Rocket/Core/Log.h"
 #include "FontFaceHandle.h"

--- a/externals/librocket/Source/Core/FontFaceHandle.cpp
+++ b/externals/librocket/Source/Core/FontFaceHandle.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontFaceHandle.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core.h"

--- a/externals/librocket/Source/Core/FontFaceHandle.h
+++ b/externals/librocket/Source/Core/FontFaceHandle.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTFACEHANDLE_H
 #define ROCKETCOREFONTFACEHANDLE_H
 

--- a/externals/librocket/Source/Core/FontFaceLayer.cpp
+++ b/externals/librocket/Source/Core/FontFaceLayer.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "FontFaceLayer.h"
 #include "../../Include/Rocket/Core/Core.h"
 #include "FontFaceHandle.h"

--- a/externals/librocket/Source/Core/FontFaceLayer.h
+++ b/externals/librocket/Source/Core/FontFaceLayer.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREFONTFACELAYER_H
 #define ROCKETCOREFONTFACELAYER_H
 

--- a/externals/librocket/Source/Core/FontFamily.cpp
+++ b/externals/librocket/Source/Core/FontFamily.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/FontFamily.h"
 #include "../../Include/Rocket/Core/FontFace.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/FontProvider.cpp
+++ b/externals/librocket/Source/Core/FontProvider.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include <Rocket/Core/FontFamily.h>
 #include <Rocket/Core/FontProvider.h>
 

--- a/externals/librocket/Source/Core/Geometry.cpp
+++ b/externals/librocket/Source/Core/Geometry.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Geometry.h"
 #include "../../Include/Rocket/Core.h"
 #include "../../Include/Rocket/Core/Context.h"

--- a/externals/librocket/Source/Core/GeometryDatabase.cpp
+++ b/externals/librocket/Source/Core/GeometryDatabase.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "GeometryDatabase.h"
 #include "../../Include/Rocket/Core/Geometry.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/GeometryDatabase.h
+++ b/externals/librocket/Source/Core/GeometryDatabase.h
@@ -14,7 +14,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,6 +24,12 @@
  * THE SOFTWARE.
  *
  */
+
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
 
 #ifndef ROCKETCOREGEOMETRYDATABASE_H
 #define ROCKETCOREGEOMETRYDATABASE_H

--- a/externals/librocket/Source/Core/GeometryUtilities.cpp
+++ b/externals/librocket/Source/Core/GeometryUtilities.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/GeometryUtilities.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/LayoutBlockBox.cpp
+++ b/externals/librocket/Source/Core/LayoutBlockBox.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "LayoutBlockBox.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/ElementScroll.h"

--- a/externals/librocket/Source/Core/LayoutBlockBox.h
+++ b/externals/librocket/Source/Core/LayoutBlockBox.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELAYOUTBLOCKBOX_H
 #define ROCKETCORELAYOUTBLOCKBOX_H
 

--- a/externals/librocket/Source/Core/LayoutBlockBoxSpace.cpp
+++ b/externals/librocket/Source/Core/LayoutBlockBoxSpace.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "LayoutBlockBoxSpace.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/ElementScroll.h"

--- a/externals/librocket/Source/Core/LayoutBlockBoxSpace.h
+++ b/externals/librocket/Source/Core/LayoutBlockBoxSpace.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELAYOUTBLOCKBOXSPACE_H
 #define ROCKETCORELAYOUTBLOCKBOXSPACE_H
 

--- a/externals/librocket/Source/Core/LayoutEngine.cpp
+++ b/externals/librocket/Source/Core/LayoutEngine.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "LayoutEngine.h"
 #include <math.h>
 #include "../../Include/Rocket/Core/Element.h"

--- a/externals/librocket/Source/Core/LayoutEngine.h
+++ b/externals/librocket/Source/Core/LayoutEngine.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELAYOUTENGINE_H
 #define ROCKETCORELAYOUTENGINE_H
 

--- a/externals/librocket/Source/Core/LayoutInlineBox.cpp
+++ b/externals/librocket/Source/Core/LayoutInlineBox.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "LayoutInlineBox.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Core/LayoutInlineBox.h
+++ b/externals/librocket/Source/Core/LayoutInlineBox.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELAYOUTINLINEBOX_H
 #define ROCKETCORELAYOUTINLINEBOX_H
 

--- a/externals/librocket/Source/Core/LayoutInlineBoxText.cpp
+++ b/externals/librocket/Source/Core/LayoutInlineBoxText.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "LayoutInlineBoxText.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"

--- a/externals/librocket/Source/Core/LayoutInlineBoxText.h
+++ b/externals/librocket/Source/Core/LayoutInlineBoxText.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELAYOUTINLINEBOXTEXT_H
 #define ROCKETCORELAYOUTINLINEBOXTEXT_H
 

--- a/externals/librocket/Source/Core/LayoutLineBox.cpp
+++ b/externals/librocket/Source/Core/LayoutLineBox.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "LayoutLineBox.h"
 #include <stack>
 #include "../../Include/Rocket/Core/ElementText.h"

--- a/externals/librocket/Source/Core/LayoutLineBox.h
+++ b/externals/librocket/Source/Core/LayoutLineBox.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORELAYOUTLINEBOX_H
 #define ROCKETCORELAYOUTLINEBOX_H
 

--- a/externals/librocket/Source/Core/Log.cpp
+++ b/externals/librocket/Source/Core/Log.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Log.h"
 #include <assert.h>
 #include "../../Include/Rocket/Core.h"

--- a/externals/librocket/Source/Core/Math.cpp
+++ b/externals/librocket/Source/Core/Math.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Math.h"
 #include <math.h>
 #include <time.h>

--- a/externals/librocket/Source/Core/Plugin.cpp
+++ b/externals/librocket/Source/Core/Plugin.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Plugin.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/PluginRegistry.cpp
+++ b/externals/librocket/Source/Core/PluginRegistry.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "PluginRegistry.h"
 #include "../../Include/Rocket/Core/Context.h"
 #include "../../Include/Rocket/Core/Plugin.h"

--- a/externals/librocket/Source/Core/PluginRegistry.h
+++ b/externals/librocket/Source/Core/PluginRegistry.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPLUGINREGISTRY_H
 #define ROCKETCOREPLUGINREGISTRY_H
 

--- a/externals/librocket/Source/Core/Pool.h
+++ b/externals/librocket/Source/Core/Pool.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPOOL_H
 #define ROCKETCOREPOOL_H
 

--- a/externals/librocket/Source/Core/Property.cpp
+++ b/externals/librocket/Source/Core/Property.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Property.h"
 #include "../../Include/Rocket/Core/PropertyDefinition.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/PropertyDefinition.cpp
+++ b/externals/librocket/Source/Core/PropertyDefinition.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/PropertyDefinition.h"
 #include "../../Include/Rocket/Core/Log.h"
 #include "../../Include/Rocket/Core/StyleSheetSpecification.h"

--- a/externals/librocket/Source/Core/PropertyDictionary.cpp
+++ b/externals/librocket/Source/Core/PropertyDictionary.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/PropertyDictionary.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/PropertyParserColour.cpp
+++ b/externals/librocket/Source/Core/PropertyParserColour.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "PropertyParserColour.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/PropertyParserColour.h
+++ b/externals/librocket/Source/Core/PropertyParserColour.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYPARSERCOLOUR_H
 #define ROCKETCOREPROPERTYPARSERCOLOUR_H
 

--- a/externals/librocket/Source/Core/PropertyParserKeyword.cpp
+++ b/externals/librocket/Source/Core/PropertyParserKeyword.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "PropertyParserKeyword.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/PropertyParserKeyword.h
+++ b/externals/librocket/Source/Core/PropertyParserKeyword.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYPARSERKEYWORD_H
 #define ROCKETCOREPROPERTYPARSERKEYWORD_H
 

--- a/externals/librocket/Source/Core/PropertyParserNumber.cpp
+++ b/externals/librocket/Source/Core/PropertyParserNumber.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "PropertyParserNumber.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/PropertyParserNumber.h
+++ b/externals/librocket/Source/Core/PropertyParserNumber.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYPARSERNUMBER_H
 #define ROCKETCOREPROPERTYPARSERNUMBER_H
 

--- a/externals/librocket/Source/Core/PropertyParserString.cpp
+++ b/externals/librocket/Source/Core/PropertyParserString.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "PropertyParserString.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/PropertyParserString.h
+++ b/externals/librocket/Source/Core/PropertyParserString.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYPARSERSTRING_H
 #define ROCKETCOREPROPERTYPARSERSTRING_H
 

--- a/externals/librocket/Source/Core/PropertyShorthandDefinition.h
+++ b/externals/librocket/Source/Core/PropertyShorthandDefinition.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPROPERTYSHORTHANDDEFINITION_H
 #define ROCKETCOREPROPERTYSHORTHANDDEFINITION_H
 

--- a/externals/librocket/Source/Core/PropertySpecification.cpp
+++ b/externals/librocket/Source/Core/PropertySpecification.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/PropertySpecification.h"
 #include "../../Include/Rocket/Core/Log.h"
 #include "../../Include/Rocket/Core/PropertyDefinition.h"

--- a/externals/librocket/Source/Core/ReferenceCountable.cpp
+++ b/externals/librocket/Source/Core/ReferenceCountable.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/ReferenceCountable.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/RenderInterface.cpp
+++ b/externals/librocket/Source/Core/RenderInterface.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/RenderInterface.h"
 #include "TextureDatabase.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/Stream.cpp
+++ b/externals/librocket/Source/Core/Stream.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Stream.h"
 #include <stdio.h>
 #include <algorithm>

--- a/externals/librocket/Source/Core/StreamFile.cpp
+++ b/externals/librocket/Source/Core/StreamFile.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "StreamFile.h"
 #include "../../Include/Rocket/Core.h"
 #include "../../Include/Rocket/Core/FileInterface.h"

--- a/externals/librocket/Source/Core/StreamFile.h
+++ b/externals/librocket/Source/Core/StreamFile.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTREAMFILE_H
 #define ROCKETCORESTREAMFILE_H
 

--- a/externals/librocket/Source/Core/StreamMemory.cpp
+++ b/externals/librocket/Source/Core/StreamMemory.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/StreamMemory.h"
 #include <stdio.h>
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/String.cpp
+++ b/externals/librocket/Source/Core/String.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/String.h"
 #include "../../Include/Rocket/Core/StringBase.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/StringCache.cpp
+++ b/externals/librocket/Source/Core/StringCache.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "precompiled.h"
 
 namespace Rocket {

--- a/externals/librocket/Source/Core/StringCache.h
+++ b/externals/librocket/Source/Core/StringCache.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTRINGCACHE_H
 #define ROCKETCORESTRINGCACHE_H
 

--- a/externals/librocket/Source/Core/StringUtilities.cpp
+++ b/externals/librocket/Source/Core/StringUtilities.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/StringUtilities.h"
 #include <ctype.h>
 #include <stdio.h>

--- a/externals/librocket/Source/Core/StyleSheet.cpp
+++ b/externals/librocket/Source/Core/StyleSheet.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/StyleSheet.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core/Element.h"

--- a/externals/librocket/Source/Core/StyleSheetFactory.cpp
+++ b/externals/librocket/Source/Core/StyleSheetFactory.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetFactory.h"
 #include "../../Include/Rocket/Core/Context.h"
 #include "../../Include/Rocket/Core/Log.h"

--- a/externals/librocket/Source/Core/StyleSheetFactory.h
+++ b/externals/librocket/Source/Core/StyleSheetFactory.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETFACTORY_H
 #define ROCKETCORESTYLESHEETFACTORY_H
 

--- a/externals/librocket/Source/Core/StyleSheetNode.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNode.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNode.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core/Element.h"

--- a/externals/librocket/Source/Core/StyleSheetNode.h
+++ b/externals/librocket/Source/Core/StyleSheetNode.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODE_H
 #define ROCKETCORESTYLESHEETNODE_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelector.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelector.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelector.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelector.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelector.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTOR_H
 #define ROCKETCORESTYLESHEETNODESELECTOR_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorEmpty.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorEmpty.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorEmpty.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorEmpty.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorEmpty.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTOREMPTY_H
 #define ROCKETCORESTYLESHEETNODESELECTOREMPTY_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstChild.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstChild.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorFirstChild.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstChild.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstChild.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORFIRSTCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORFIRSTCHILD_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstOfType.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstOfType.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorFirstOfType.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstOfType.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorFirstOfType.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORFIRSTOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORFIRSTOFTYPE_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorLastChild.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorLastChild.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorLastChild.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorLastChild.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorLastChild.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORLASTCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORLASTCHILD_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorLastOfType.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorLastOfType.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorLastOfType.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorLastOfType.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorLastOfType.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORLASTOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORLASTOFTYPE_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthChild.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthChild.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorNthChild.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/Log.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthChild.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthChild.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHCHILD_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastChild.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastChild.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorNthLastChild.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastChild.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastChild.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHLASTCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHLASTCHILD_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastOfType.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastOfType.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorNthLastOfType.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastOfType.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthLastOfType.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHLASTOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHLASTOFTYPE_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthOfType.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthOfType.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorNthOfType.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorNthOfType.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorNthOfType.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORNTHOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORNTHOFTYPE_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyChild.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyChild.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorOnlyChild.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyChild.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyChild.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORONLYCHILD_H
 #define ROCKETCORESTYLESHEETNODESELECTORONLYCHILD_H
 

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyOfType.cpp
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyOfType.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetNodeSelectorOnlyOfType.h"
 #include "../../Include/Rocket/Core/ElementText.h"
 #include "../../Include/Rocket/Core/StyleSheetKeywords.h"

--- a/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyOfType.h
+++ b/externals/librocket/Source/Core/StyleSheetNodeSelectorOnlyOfType.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETNODESELECTORONLYOFTYPE_H
 #define ROCKETCORESTYLESHEETNODESELECTORONLYOFTYPE_H
 

--- a/externals/librocket/Source/Core/StyleSheetParser.cpp
+++ b/externals/librocket/Source/Core/StyleSheetParser.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "StyleSheetParser.h"
 #include <algorithm>
 #include "../../Include/Rocket/Core/Log.h"

--- a/externals/librocket/Source/Core/StyleSheetParser.h
+++ b/externals/librocket/Source/Core/StyleSheetParser.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORESTYLESHEETPARSER_H
 #define ROCKETCORESTYLESHEETPARSER_H
 

--- a/externals/librocket/Source/Core/StyleSheetSpecification.cpp
+++ b/externals/librocket/Source/Core/StyleSheetSpecification.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/StyleSheetSpecification.h"
 #include "PropertyParserColour.h"
 #include "PropertyParserKeyword.h"

--- a/externals/librocket/Source/Core/SystemInterface.cpp
+++ b/externals/librocket/Source/Core/SystemInterface.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/SystemInterface.h"
 #include "../../Include/Rocket/Core/Log.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/TTFFont/FontFace.h
+++ b/externals/librocket/Source/Core/TTFFont/FontFace.h
@@ -1,6 +1,36 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETTFFONTFACE_H
 #define ROCKETCORETTFFONTFACE_H
 

--- a/externals/librocket/Source/Core/TTFFont/FontFaceHandle.h
+++ b/externals/librocket/Source/Core/TTFFont/FontFaceHandle.h
@@ -1,6 +1,36 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETTFFONTFACEHANDLE_H
 #define ROCKETCORETTFFONTFACEHANDLE_H
 

--- a/externals/librocket/Source/Core/TTFFont/FontFaceLayer.h
+++ b/externals/librocket/Source/Core/TTFFont/FontFaceLayer.h
@@ -1,6 +1,36 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETTFFONTFACELAYER_H
 #define ROCKETCORETTFFONTFACELAYER_H
 

--- a/externals/librocket/Source/Core/TTFFont/FontFamily.h
+++ b/externals/librocket/Source/Core/TTFFont/FontFamily.h
@@ -1,6 +1,36 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETTFFONTFAMILY_H
 #define ROCKETCORETTFFONTFAMILY_H
 

--- a/externals/librocket/Source/Core/TTFFont/FontProvider.cpp
+++ b/externals/librocket/Source/Core/TTFFont/FontProvider.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include <Rocket/Core.h>
 #include <Rocket/Core/FontDatabase.h>
 #include <Rocket/Core/StreamMemory.h>

--- a/externals/librocket/Source/Core/TTFFont/TTFFontDefinitions.h
+++ b/externals/librocket/Source/Core/TTFFont/TTFFontDefinitions.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef TTFFONTDEFINITIONS_H
 #define TTFFONTDEFINITIONS_H
 

--- a/externals/librocket/Source/Core/Template.cpp
+++ b/externals/librocket/Source/Core/Template.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "Template.h"
 #include "../../Include/Rocket/Core/ElementUtilities.h"
 #include "../../Include/Rocket/Core/XMLParser.h"

--- a/externals/librocket/Source/Core/Template.h
+++ b/externals/librocket/Source/Core/Template.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETEMPLATE_H
 #define ROCKETCORETEMPLATE_H
 

--- a/externals/librocket/Source/Core/TemplateCache.cpp
+++ b/externals/librocket/Source/Core/TemplateCache.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "TemplateCache.h"
 #include "../../Include/Rocket/Core/Log.h"
 #include "StreamFile.h"

--- a/externals/librocket/Source/Core/TemplateCache.h
+++ b/externals/librocket/Source/Core/TemplateCache.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETEMPLATECACHE_H
 #define ROCKETCORETEMPLATECACHE_H
 

--- a/externals/librocket/Source/Core/Texture.cpp
+++ b/externals/librocket/Source/Core/Texture.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Texture.h"
 #include "TextureDatabase.h"
 #include "TextureResource.h"

--- a/externals/librocket/Source/Core/TextureDatabase.cpp
+++ b/externals/librocket/Source/Core/TextureDatabase.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "TextureDatabase.h"
 #include "../../Include/Rocket/Core.h"
 #include "../../Include/Rocket/Core/Context.h"

--- a/externals/librocket/Source/Core/TextureDatabase.h
+++ b/externals/librocket/Source/Core/TextureDatabase.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETEXTUREDATABASE_H
 #define ROCKETCORETEXTUREDATABASE_H
 

--- a/externals/librocket/Source/Core/TextureLayout.cpp
+++ b/externals/librocket/Source/Core/TextureLayout.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "TextureLayout.h"
 #include <algorithm>
 #include "TextureLayoutRectangle.h"

--- a/externals/librocket/Source/Core/TextureLayout.h
+++ b/externals/librocket/Source/Core/TextureLayout.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef TEXTURELAYOUT_H
 #define TEXTURELAYOUT_H
 

--- a/externals/librocket/Source/Core/TextureLayoutRectangle.cpp
+++ b/externals/librocket/Source/Core/TextureLayoutRectangle.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "TextureLayoutRectangle.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/TextureLayoutRectangle.h
+++ b/externals/librocket/Source/Core/TextureLayoutRectangle.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef TEXTURELAYOUTRECTANGLE_H
 #define TEXTURELAYOUTRECTANGLE_H
 

--- a/externals/librocket/Source/Core/TextureLayoutRow.cpp
+++ b/externals/librocket/Source/Core/TextureLayoutRow.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "TextureLayoutRow.h"
 #include "TextureLayout.h"
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/TextureLayoutRow.h
+++ b/externals/librocket/Source/Core/TextureLayoutRow.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef TEXTURELAYOUTROW_H
 #define TEXTURELAYOUTROW_H
 

--- a/externals/librocket/Source/Core/TextureLayoutTexture.cpp
+++ b/externals/librocket/Source/Core/TextureLayoutTexture.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "TextureLayoutTexture.h"
 #include "../../Include/Rocket/Core/Core.h"
 #include "TextureDatabase.h"

--- a/externals/librocket/Source/Core/TextureLayoutTexture.h
+++ b/externals/librocket/Source/Core/TextureLayoutTexture.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef TEXTURELAYOUTTEXTURE_H
 #define TEXTURELAYOUTTEXTURE_H
 

--- a/externals/librocket/Source/Core/TextureResource.cpp
+++ b/externals/librocket/Source/Core/TextureResource.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "TextureResource.h"
 #include "../../Include/Rocket/Core.h"
 #include "FontFaceHandle.h"

--- a/externals/librocket/Source/Core/TextureResource.h
+++ b/externals/librocket/Source/Core/TextureResource.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCORETEXTURERESOURCE_H
 #define ROCKETCORETEXTURERESOURCE_H
 

--- a/externals/librocket/Source/Core/URL.cpp
+++ b/externals/librocket/Source/Core/URL.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/URL.h"
 #include <stdio.h>
 #include "precompiled.h"

--- a/externals/librocket/Source/Core/UnicodeRange.cpp
+++ b/externals/librocket/Source/Core/UnicodeRange.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "UnicodeRange.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/UnicodeRange.h
+++ b/externals/librocket/Source/Core/UnicodeRange.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREUNICODERANGE_H
 #define ROCKETCOREUNICODERANGE_H
 

--- a/externals/librocket/Source/Core/Variant.cpp
+++ b/externals/librocket/Source/Core/Variant.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/Variant.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/WString.cpp
+++ b/externals/librocket/Source/Core/WString.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/WString.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/WidgetSlider.cpp
+++ b/externals/librocket/Source/Core/WidgetSlider.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetSlider.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Event.h"

--- a/externals/librocket/Source/Core/WidgetSlider.h
+++ b/externals/librocket/Source/Core/WidgetSlider.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREWIDGETSLIDER_H
 #define ROCKETCOREWIDGETSLIDER_H
 

--- a/externals/librocket/Source/Core/WidgetSliderScroll.cpp
+++ b/externals/librocket/Source/Core/WidgetSliderScroll.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "WidgetSliderScroll.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/WidgetSliderScroll.h
+++ b/externals/librocket/Source/Core/WidgetSliderScroll.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREWIDGETSLIDERSCROLL_H
 #define ROCKETCOREWIDGETSLIDERSCROLL_H
 

--- a/externals/librocket/Source/Core/XMLNodeHandler.cpp
+++ b/externals/librocket/Source/Core/XMLNodeHandler.cpp
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/XMLNodeHandler.h"
 #include "precompiled.h"
 

--- a/externals/librocket/Source/Core/XMLNodeHandlerBody.cpp
+++ b/externals/librocket/Source/Core/XMLNodeHandlerBody.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerBody.h"
 #include "../../Include/Rocket/Core.h"
 #include "XMLParseTools.h"

--- a/externals/librocket/Source/Core/XMLNodeHandlerBody.h
+++ b/externals/librocket/Source/Core/XMLNodeHandlerBody.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLNODEHANDLERBODY_H
 #define ROCKETCOREXMLNODEHANDLERBODY_H
 

--- a/externals/librocket/Source/Core/XMLNodeHandlerDefault.cpp
+++ b/externals/librocket/Source/Core/XMLNodeHandlerDefault.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerDefault.h"
 #include "../../Include/Rocket/Core/Element.h"
 #include "../../Include/Rocket/Core/Factory.h"

--- a/externals/librocket/Source/Core/XMLNodeHandlerDefault.h
+++ b/externals/librocket/Source/Core/XMLNodeHandlerDefault.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLNODEHANDLERDEFAULT_H
 #define ROCKETCOREXMLNODEHANDLERDEFAULT_H
 

--- a/externals/librocket/Source/Core/XMLNodeHandlerHead.cpp
+++ b/externals/librocket/Source/Core/XMLNodeHandlerHead.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerHead.h"
 #include "../../Include/Rocket/Core.h"
 #include "DocumentHeader.h"

--- a/externals/librocket/Source/Core/XMLNodeHandlerHead.h
+++ b/externals/librocket/Source/Core/XMLNodeHandlerHead.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLNODEHANDLERHEAD_H
 #define ROCKETCOREXMLNODEHANDLERHEAD_H
 

--- a/externals/librocket/Source/Core/XMLNodeHandlerTemplate.cpp
+++ b/externals/librocket/Source/Core/XMLNodeHandlerTemplate.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLNodeHandlerTemplate.h"
 #include "../../Include/Rocket/Core.h"
 #include "Template.h"

--- a/externals/librocket/Source/Core/XMLNodeHandlerTemplate.h
+++ b/externals/librocket/Source/Core/XMLNodeHandlerTemplate.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLNODEHANDLERTEMPLATE_H
 #define ROCKETCOREXMLNODEHANDLERTEMPLATE_H
 

--- a/externals/librocket/Source/Core/XMLParseTools.cpp
+++ b/externals/librocket/Source/Core/XMLParseTools.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "XMLParseTools.h"
 #include <ctype.h>
 #ifdef __APPLE__

--- a/externals/librocket/Source/Core/XMLParseTools.h
+++ b/externals/librocket/Source/Core/XMLParseTools.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREXMLPARSETOOLS_H
 #define ROCKETCOREXMLPARSETOOLS_H
 

--- a/externals/librocket/Source/Core/XMLParser.cpp
+++ b/externals/librocket/Source/Core/XMLParser.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Core/XMLParser.h"
 #include "../../Include/Rocket/Core/Log.h"
 #include "../../Include/Rocket/Core/XMLNodeHandler.h"

--- a/externals/librocket/Source/Core/precompiled.h
+++ b/externals/librocket/Source/Core/precompiled.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETCOREPRECOMPILED_H
 #define ROCKETCOREPRECOMPILED_H
 

--- a/externals/librocket/Source/Debugger/Debugger.cpp
+++ b/externals/librocket/Source/Debugger/Debugger.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "../../Include/Rocket/Debugger/Debugger.h"
 #include "../../Include/Rocket/Core.h"
 #include "Plugin.h"

--- a/externals/librocket/Source/Debugger/ElementContextHook.cpp
+++ b/externals/librocket/Source/Debugger/ElementContextHook.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementContextHook.h"
 #include "Plugin.h"
 

--- a/externals/librocket/Source/Debugger/ElementContextHook.h
+++ b/externals/librocket/Source/Debugger/ElementContextHook.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERELEMENTCONTEXTHOOK_H
 #define ROCKETDEBUGGERELEMENTCONTEXTHOOK_H
 

--- a/externals/librocket/Source/Debugger/ElementInfo.cpp
+++ b/externals/librocket/Source/Debugger/ElementInfo.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementInfo.h"
 #include <map>
 #include "../../Include/Rocket/Core/Factory.h"

--- a/externals/librocket/Source/Debugger/ElementInfo.h
+++ b/externals/librocket/Source/Debugger/ElementInfo.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERELEMENTINFO_H
 #define ROCKETDEBUGGERELEMENTINFO_H
 

--- a/externals/librocket/Source/Debugger/ElementLog.cpp
+++ b/externals/librocket/Source/Debugger/ElementLog.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "ElementLog.h"
 #include "../../Include/Rocket/Core.h"
 #include "BeaconSource.h"

--- a/externals/librocket/Source/Debugger/ElementLog.h
+++ b/externals/librocket/Source/Debugger/ElementLog.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERELEMENTLOG_H
 #define ROCKETDEBUGGERELEMENTLOG_H
 

--- a/externals/librocket/Source/Debugger/FontSource.h
+++ b/externals/librocket/Source/Debugger/FontSource.h
@@ -25,6 +25,12 @@
  *
  */
 
+// Copyright (c) 2022, WNProject Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERFONTSOURCE_H
 #define ROCKETDEBUGGERFONTSOURCE_H
 

--- a/externals/librocket/Source/Debugger/Geometry.cpp
+++ b/externals/librocket/Source/Debugger/Geometry.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "Geometry.h"
 #include "../../Include/Rocket/Core.h"
 #include "../../Include/Rocket/Core/Context.h"

--- a/externals/librocket/Source/Debugger/Geometry.h
+++ b/externals/librocket/Source/Debugger/Geometry.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERGEOMETRY_H
 #define ROCKETDEBUGGERGEOMETRY_H
 

--- a/externals/librocket/Source/Debugger/Plugin.cpp
+++ b/externals/librocket/Source/Debugger/Plugin.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "Plugin.h"
 #include <stack>
 #include "../../Include/Rocket/Core.h"

--- a/externals/librocket/Source/Debugger/Plugin.h
+++ b/externals/librocket/Source/Debugger/Plugin.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERPLUGIN_H
 #define ROCKETDEBUGGERPLUGIN_H
 

--- a/externals/librocket/Source/Debugger/SystemInterface.cpp
+++ b/externals/librocket/Source/Debugger/SystemInterface.cpp
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #include "SystemInterface.h"
 #include "../../Include/Rocket/Core.h"
 #include "ElementLog.h"

--- a/externals/librocket/Source/Debugger/SystemInterface.h
+++ b/externals/librocket/Source/Debugger/SystemInterface.h
@@ -24,9 +24,13 @@
  * THE SOFTWARE.
  *
  */
+
 // Copyright (c) 2022, WNProject Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// clang-format off
+
 #ifndef ROCKETDEBUGGERSYSTEMINTERFACE_H
 #define ROCKETDEBUGGERSYSTEMINTERFACE_H
 


### PR DESCRIPTION
This moves the analyze stuff out of the CI workflow and into the pull request workflow. The CI workflow now will run everything unless filtered down to a set of changes. Doing it this way required disabling clang format on `librocket` since I couldn't get a exclusionary glob thing working correctly and it's really not worth it.