### PR TITLE
Clean up sccache usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
   build-android:
     name: Build Android
     if: inputs.run-build
-    timeout-minutes: ${{github.actor == 'dependabot[bot]' && 120 || 60}}
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-android
     strategy:
@@ -270,7 +270,7 @@ jobs:
   build-linux:
     name: Build Linux
     if: inputs.run-build
-    timeout-minutes: ${{github.actor == 'dependabot[bot]' && 120 || 60}}
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-linux:${{matrix.compiler}}
     strategy:
@@ -337,7 +337,7 @@ jobs:
   build-windows:
     name: Build Windows
     if: inputs.run-build
-    timeout-minutes: ${{github.actor == 'dependabot[bot]' && 120 || 60}}
+    timeout-minutes: 120
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,16 +388,16 @@ jobs:
       - name: Run configuration
         run: >
           docker run --rm
-          -e SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET
+          -e SCCACHE_GCS_BUCKET="$env:SCCACHE_GCS_BUCKET"
           -e SCCACHE_GCS_KEY_PATH=C:\workspace\gcs_key.json
-          -e SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE
-          -e SCCACHE_IGNORE_SERVER_IO_ERROR=$env:SCCACHE_IGNORE_SERVER_IO_ERROR
+          -e SCCACHE_GCS_RW_MODE="$env:SCCACHE_GCS_RW_MODE"
+          -e SCCACHE_IGNORE_SERVER_IO_ERROR="$env:SCCACHE_IGNORE_SERVER_IO_ERROR"
           -v ${{github.workspace}}:C:\workspace
           $env:DOCKER_IMAGE
           cmake -GNinja -S C:\workspace\source -B C:\workspace\build
-          -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE
+          -DCMAKE_BUILD_TYPE="$env:BUILD_TYPE"
           -DWN_LOW_RESOURCE_MODE=ON
-          -DWN_USE_SCCACHE=$env:USE_SCCACHE
+          -DWN_USE_SCCACHE="$env:USE_SCCACHE"
         env:
           BUILD_TYPE: ${{matrix.build-type}}
           DOCKER_IMAGE: ${{steps.build-environment.outputs.docker-image}}
@@ -405,10 +405,10 @@ jobs:
       - name: Run build
         run: >
           docker run --rm
-          -e SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET
+          -e SCCACHE_GCS_BUCKET="$env:SCCACHE_GCS_BUCKET"
           -e SCCACHE_GCS_KEY_PATH=C:\workspace\gcs_key.json
-          -e SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE
-          -e SCCACHE_IGNORE_SERVER_IO_ERROR=$env:SCCACHE_IGNORE_SERVER_IO_ERROR
+          -e SCCACHE_GCS_RW_MODE="$env:SCCACHE_GCS_RW_MODE"
+          -e SCCACHE_IGNORE_SERVER_IO_ERROR="$env:SCCACHE_IGNORE_SERVER_IO_ERROR"
           -v ${{github.workspace}}:C:\workspace
           $env:DOCKER_IMAGE
           cmake --build C:\workspace\build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ on:
         required: false
         default: '**/*.md'
         type: string
+      use-sccache:
+        required: true
+        type: boolean
+      sccache-write:
+        required: false
+        default: false
+        type: boolean
 permissions:
   contents: read
 jobs:
@@ -188,7 +195,7 @@ jobs:
   build-android:
     name: Build Android
     if: inputs.run-build
-    timeout-minutes: 90
+    timeout-minutes: ${{github.actor == 'dependabot[bot]' && 120 || 60}}
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-android
     strategy:
@@ -209,10 +216,23 @@ jobs:
         with:
           path: ./source
           submodules: true
-      - name: Set up GCS key
+      - name: Set up GCS for sccache
+        if: inputs.use-sccache
         shell: bash
-        run: echo "$GCS_KEY" > /tmp/gcs_key.json
+        run: |
+          KEY_PATH="$RUNNER_TEMP/gcs_key.json"
+          echo "$GCS_KEY" > "$KEY_PATH"
+          echo "SCCACHE_GCS_BUCKET=$GCS_BUCKET" >> $GITHUB_ENV
+          echo "SCCACHE_GCS_KEY_PATH=$KEY_PATH" >> $GITHUB_ENV
+          RW_MODE=$(
+            [ "$INPUTS_SCCACHE_WRITE" == 'true' ] &&
+            echo 'READ_WRITE' ||
+            echo 'READ_ONLY'
+          )
+          echo "SCCACHE_GCS_RW_MODE=$RW_MODE" >> $GITHUB_ENV
         env:
+          INPUTS_SCCACHE_WRITE: ${{inputs.sccache-write}}
+          GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
           GCS_KEY: ${{secrets.SCCACHE_GCS_KEY}}
       - name: Run configuration
         working-directory: ./build
@@ -223,48 +243,33 @@ jobs:
           -DWN_ANDROID_ABIS="$ARCHITECTURE"
           -DWN_ANDROID_SDK=/opt/android-sdk
           -DWN_LOW_RESOURCE_MODE=ON
-          -DWN_USE_SCCACHE=ON
+          -DWN_USE_SCCACHE="$USE_SCCACHE"
           ../source
         env:
-          OVERLAY: ${{github.workspace}}/source/Overlays/Posix/Overlays/Android
-          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
-          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
-          SCCACHE_GCS_RW_MODE: READ_WRITE
           ARCHITECTURE: ${{matrix.architecture}}
           BUILT_TYPE: ${{matrix.build-type}}
+          OVERLAY: ${{github.workspace}}/source/Overlays/Posix/Overlays/Android
+          USE_SCCACHE: ${{inputs.use-sccache && 'ON' || 'OFF' }}
       - name: Run build (host tools)
         working-directory: ./build/host/externals/llvm-project/llvm
         run: cmake --build . --target llvm-tblgen
-        env:
-          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
-          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
-          SCCACHE_GCS_RW_MODE: READ_WRITE
       - name: 'Run build (platform: ${{matrix.architecture}})'
         working-directory: ./build/${{matrix.architecture}}
         run: cmake --build .
-        env:
-          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
-          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
-          SCCACHE_GCS_RW_MODE: READ_WRITE
       - name: Run build (apks)
         working-directory: ./build
         run: cmake --build .
-        env:
-          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
-          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
-          SCCACHE_GCS_RW_MODE: READ_WRITE
       - name: Run tests
         working-directory: ./build
         run: ctest -C "$BUILD_TYPE" -LE REQUIRES_HARDWARE --output-on-failure
         env:
           BUILD_TYPE: ${{matrix.build-type}}
       - name: Report build details
-        if: success() || failure()
         run: du -hbcs ./source ./build
   build-linux:
     name: Build Linux
     if: inputs.run-build
-    timeout-minutes: 90
+    timeout-minutes: ${{github.actor == 'dependabot[bot]' && 120 || 60}}
     runs-on: ubuntu-latest
     container: ghcr.io/wnproject/build-linux:${{matrix.compiler}}
     strategy:
@@ -288,10 +293,23 @@ jobs:
         with:
           path: ./source
           submodules: true
-      - name: Set up GCS key
+      - name: Set up GCS for sccache
+        if: inputs.use-sccache
         shell: bash
-        run: echo "$GCS_KEY" > /tmp/gcs_key.json
+        run: |
+          KEY_PATH="$RUNNER_TEMP/gcs_key.json"
+          echo "$GCS_KEY" > "$KEY_PATH"
+          echo "SCCACHE_GCS_BUCKET=$GCS_BUCKET" >> $GITHUB_ENV
+          echo "SCCACHE_GCS_KEY_PATH=$KEY_PATH" >> $GITHUB_ENV
+          RW_MODE=$(
+            [ "$INPUTS_SCCACHE_WRITE" == 'true' ] &&
+            echo 'READ_WRITE' ||
+            echo 'READ_ONLY'
+          )
+          echo "SCCACHE_GCS_RW_MODE=$RW_MODE" >> $GITHUB_ENV
         env:
+          INPUTS_SCCACHE_WRITE: ${{inputs.sccache-write}}
+          GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
           GCS_KEY: ${{secrets.SCCACHE_GCS_KEY}}
       - name: Run configuration
         working-directory: ./build
@@ -299,32 +317,25 @@ jobs:
           cmake -GNinja
           -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
           -DWN_LOW_RESOURCE_MODE=ON
-          -DWN_USE_SCCACHE=ON
+          -DWN_USE_SCCACHE="$USE_SCCACHE"
           ../source
         env:
-          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
-          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
-          SCCACHE_GCS_RW_MODE: READ_WRITE
           BUILD_TYPE: ${{matrix.build-type}}
+          USE_SCCACHE: ${{inputs.use-sccache && 'ON' || 'OFF' }}
       - name: Run build
         working-directory: ./build
         run: cmake --build .
-        env:
-          SCCACHE_GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
-          SCCACHE_GCS_KEY_PATH: /tmp/gcs_key.json
-          SCCACHE_GCS_RW_MODE: READ_WRITE
       - name: Run tests
         working-directory: ./build
         run: ctest -C "$BUILD_TYPE" -LE REQUIRES_HARDWARE --output-on-failure
         env:
           BUILD_TYPE: ${{matrix.build-type}}
       - name: Report build details
-        if: success() || failure()
         run: du -hbcs ./source ./build
   build-windows:
     name: Build Windows
     if: inputs.run-build
-    timeout-minutes: 90
+    timeout-minutes: ${{github.actor == 'dependabot[bot]' && 120 || 60}}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -350,10 +361,22 @@ jobs:
         with:
           path: ./source
           submodules: true
-      - name: Set up GCS key
+      - name: Set up GCS for sccache
+        if: inputs.use-sccache
         shell: bash
-        run: echo "$GCS_KEY" > gcs_key.json
+        run: |
+          KEY_PATH="$GITHUB_WORKSPACE/gcs_key.json"
+          echo "$GCS_KEY" > "$KEY_PATH"
+          echo "SCCACHE_GCS_BUCKET=$GCS_BUCKET" >> $GITHUB_ENV
+          RW_MODE=$(
+            [ "$INPUTS_SCCACHE_WRITE" == 'true' ] &&
+            echo 'READ_WRITE' ||
+            echo 'READ_ONLY'
+          )
+          echo "SCCACHE_GCS_RW_MODE=$RW_MODE" >> $GITHUB_ENV
         env:
+          INPUTS_SCCACHE_WRITE: ${{inputs.sccache-write}}
+          GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
           GCS_KEY: ${{secrets.SCCACHE_GCS_KEY}}
       - name: Pull container
         run: docker pull $env:DOCKER_IMAGE
@@ -362,35 +385,43 @@ jobs:
       - name: Run configuration
         run: >
           docker run --rm
-          -e SCCACHE_GCS_BUCKET=${{secrets.SCCACHE_GCS_BUCKET}}
+          -e "SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET"
           -e SCCACHE_GCS_KEY_PATH=C:\workspace\gcs_key.json
-          -e SCCACHE_GCS_RW_MODE=READ_WRITE
+          -e "SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE"
           -v ${{github.workspace}}:C:\workspace
-          ${{steps.build-environment.outputs.docker-image}}
+          $env:DOCKER_IMAGE
           cmake -GNinja -S C:\workspace\source -B C:\workspace\build
-          -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+          -DCMAKE_BUILD_TYPE="$env:BUILD_TYPE"
           -DWN_LOW_RESOURCE_MODE=ON
-          -DWN_USE_SCCACHE=ON
+          -DWN_USE_SCCACHE="$env:USE_SCCACHE"
+        env:
+          BUILD_TYPE: ${{matrix.build-type}}
+          DOCKER_IMAGE: ${{steps.build-environment.outputs.docker-image}}
+          USE_SCCACHE: ${{inputs.use-sccache && 'ON' || 'OFF' }}
       - name: Run build
         run: >
           docker run --rm
-          -e SCCACHE_GCS_BUCKET=${{secrets.SCCACHE_GCS_BUCKET}}
+          -e "SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET"
           -e SCCACHE_GCS_KEY_PATH=C:\workspace\gcs_key.json
-          -e SCCACHE_GCS_RW_MODE=READ_WRITE
+          -e "SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE"
           -v ${{github.workspace}}:C:\workspace
-          ${{steps.build-environment.outputs.docker-image}}
+          $env:DOCKER_IMAGE
           cmake --build C:\workspace\build
+        env:
+          DOCKER_IMAGE: ${{steps.build-environment.outputs.docker-image}}
       - name: Run tests
         run: >
           docker run --rm
           -v ${{github.workspace}}:C:\workspace
-          ${{steps.build-environment.outputs.docker-image}}
+          $env:DOCKER_IMAGE
           "cd C:\workspace\build;
-          ctest -C ${{matrix.build-type}}
+          ctest -C "$env:BUILD_TYPE"
           -LE REQUIRES_HARDWARE
           --output-on-failure"
+        env:
+          BUILD_TYPE: ${{matrix.build-type}}
+          DOCKER_IMAGE: ${{steps.build-environment.outputs.docker-image}}
       - name: Report build details
-        if: success() || failure()
         shell: bash
         run: du -hbcs ./source ./build
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
             echo 'READ_ONLY'
           )
           echo "SCCACHE_GCS_RW_MODE=$RW_MODE" >> $GITHUB_ENV
+          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> $GITHUB_ENV
         env:
           INPUTS_SCCACHE_WRITE: ${{inputs.sccache-write}}
           GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
@@ -307,6 +308,7 @@ jobs:
             echo 'READ_ONLY'
           )
           echo "SCCACHE_GCS_RW_MODE=$RW_MODE" >> $GITHUB_ENV
+          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> $GITHUB_ENV
         env:
           INPUTS_SCCACHE_WRITE: ${{inputs.sccache-write}}
           GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
@@ -374,6 +376,7 @@ jobs:
             echo 'READ_ONLY'
           )
           echo "SCCACHE_GCS_RW_MODE=$RW_MODE" >> $GITHUB_ENV
+          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> $GITHUB_ENV
         env:
           INPUTS_SCCACHE_WRITE: ${{inputs.sccache-write}}
           GCS_BUCKET: ${{secrets.SCCACHE_GCS_BUCKET}}
@@ -385,15 +388,16 @@ jobs:
       - name: Run configuration
         run: >
           docker run --rm
-          -e "SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET"
+          -e SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET
           -e SCCACHE_GCS_KEY_PATH=C:\workspace\gcs_key.json
-          -e "SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE"
+          -e SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE
+          -e SCCACHE_IGNORE_SERVER_IO_ERROR=$env:SCCACHE_IGNORE_SERVER_IO_ERROR
           -v ${{github.workspace}}:C:\workspace
           $env:DOCKER_IMAGE
           cmake -GNinja -S C:\workspace\source -B C:\workspace\build
-          -DCMAKE_BUILD_TYPE="$env:BUILD_TYPE"
+          -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE
           -DWN_LOW_RESOURCE_MODE=ON
-          -DWN_USE_SCCACHE="$env:USE_SCCACHE"
+          -DWN_USE_SCCACHE=$env:USE_SCCACHE
         env:
           BUILD_TYPE: ${{matrix.build-type}}
           DOCKER_IMAGE: ${{steps.build-environment.outputs.docker-image}}
@@ -401,9 +405,10 @@ jobs:
       - name: Run build
         run: >
           docker run --rm
-          -e "SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET"
+          -e SCCACHE_GCS_BUCKET=$env:SCCACHE_GCS_BUCKET
           -e SCCACHE_GCS_KEY_PATH=C:\workspace\gcs_key.json
-          -e "SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE"
+          -e SCCACHE_GCS_RW_MODE=$env:SCCACHE_GCS_RW_MODE
+          -e SCCACHE_IGNORE_SERVER_IO_ERROR=$env:SCCACHE_IGNORE_SERVER_IO_ERROR
           -v ${{github.workspace}}:C:\workspace
           $env:DOCKER_IMAGE
           cmake --build C:\workspace\build
@@ -415,7 +420,7 @@ jobs:
           -v ${{github.workspace}}:C:\workspace
           $env:DOCKER_IMAGE
           "cd C:\workspace\build;
-          ctest -C "$env:BUILD_TYPE"
+          ctest -C $env:BUILD_TYPE
           -LE REQUIRES_HARDWARE
           --output-on-failure"
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -136,3 +136,4 @@ jobs:
       changes-externals: ${{needs.analyze-changes.outputs.changes-externals}}
       changes-c-cpp: ${{needs.analyze-changes.outputs.changes-c-cpp}}
       changes-md: ${{needs.analyze-changes.outputs.changes-md}}
+      use-sccache: ${{github.actor != 'dependabot[bot]'}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -128,6 +128,7 @@ jobs:
     needs:
       - analyze-changes
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
     with:
       run-build: ${{needs.analyze-changes.outputs.run-build == 'true'}}
       run-check-licenses: ${{needs.analyze-changes.outputs.run-check-licenses == 'true'}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,3 +14,5 @@ jobs:
       run-check-licenses: true
       run-format-check-c-cpp: true
       run-format-check-md: true
+      use-sccache: ${{github.actor != 'dependabot[bot]'}}
+      sccache-write: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,7 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
     with:
       run-build: true
       run-check-licenses: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set(
 )
 
 if (WN_USE_SCCACHE)
+    message(STATUS "Using sccache")
+
     if (NOT CMAKE_CXX_COMPILER_LAUNCHER)
         set(CMAKE_CXX_COMPILER_LAUNCHER sccache)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,9 @@ set(
 )
 
 if (WN_USE_SCCACHE)
-    message(STATUS "Using sccache")
+    if (NOT CMAKE_C_COMPILER_LAUNCHER)
+        set(CMAKE_C_COMPILER_LAUNCHER sccache)
+    endif()
 
     if (NOT CMAKE_CXX_COMPILER_LAUNCHER)
         set(CMAKE_CXX_COMPILER_LAUNCHER sccache)


### PR DESCRIPTION
Cleans up hot sccache GCS set-up is handled. Doesn't do the set-up for dependabot PR's. Does read only for PR's and read/write for `master`. Resolves #595, resolves #425 and resolves #597.